### PR TITLE
fix: resolve incorrect path of `types` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Customizable datetime picker for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
-  "types": "lib/typescript/index.d.ts",
+  "types": "lib/typescript/src/index.d.ts",
   "react-native": "src/index",
   "source": "src/index",
   "files": [


### PR DESCRIPTION
![image](https://github.com/farhoudshapouran/react-native-ui-datepicker/assets/12469549/a8cba91d-1bd4-49f7-bcc9-39959479c71f)
