### PR TITLE
Use DATE_FORMAT when parsing selected date

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -64,7 +64,7 @@ export function isDateBetween(
 export const getFormatedDate = (date: DateType, format: string) =>
   dayjs(date).format(format);
 
-export const getDate = (date: DateType) => dayjs(date, CALENDAR_FORMAT);
+export const getDate = (date: DateType) => dayjs(date, DATE_FORMAT);
 
 export const getYearRange = (year: number) => {
   const endYear = YEAR_PAGE_SIZE * Math.ceil(year / YEAR_PAGE_SIZE);


### PR DESCRIPTION
Potential fix for #60, at least in 'single' mode.

I implemented the datepicker a few days ago in one of our projects and everything worked fine until yesterday. Not sure if a third-party library, such as Dayjs, was changed recently and if that caused this functionality to break, but I was able to narrow down the problem:

At least in the 'single' view mode, the date is sent back in the format "YYYY-MM-DD" (DATE_FORMAT) and not "YYYY-MM-DD HH:mm" (CALENDAR_FORMAT), but the CALENDAR_FORMAT is assumed while parsing.

Since I don't know the code base that well, this definitely should be tested with modes other than 'single', since that is the only mode we're using in our project. Additionally, it might be possible to get the date in the CALENDAR_FORMAT even when you're only picking a 'single' date. That would also prevent the problem and might be a more generic/better solution.