### PR TITLE
feat: Add possibility to select initial view

### DIFF
--- a/src/DateTimePicker.tsx
+++ b/src/DateTimePicker.tsx
@@ -78,7 +78,7 @@ const DateTimePicker = (
     endDate,
     dates,
     onChange,
-    startLevel = CalendarViews.day,
+    initialView = CalendarViews.day,
     ...rest
   } = props;
 
@@ -150,7 +150,7 @@ const DateTimePicker = (
       startDate,
       endDate,
       dates,
-      calendarView: startLevel,
+      calendarView: initialView,
       currentDate,
       currentYear,
     }

--- a/src/DateTimePicker.tsx
+++ b/src/DateTimePicker.tsx
@@ -78,6 +78,7 @@ const DateTimePicker = (
     endDate,
     dates,
     onChange,
+    startLevel = CalendarViews.day,
     ...rest
   } = props;
 
@@ -149,7 +150,7 @@ const DateTimePicker = (
       startDate,
       endDate,
       dates,
-      calendarView: CalendarViews.day,
+      calendarView: startLevel,
       currentDate,
       currentYear,
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,5 +91,5 @@ export interface DatePickerBaseProps {
   startDate?: DateType;
   endDate?: DateType;
   onChange?: SingleChange | RangeChange | MultiChange;
-  startLevel?: CalendarViews;
+  initialView?: CalendarViews;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,4 +91,5 @@ export interface DatePickerBaseProps {
   startDate?: DateType;
   endDate?: DateType;
   onChange?: SingleChange | RangeChange | MultiChange;
+  startLevel?: CalendarViews;
 }


### PR DESCRIPTION
This does allow to select the view that is opened first with the calendar. 
Especially useful, when selecting dates such as birthdays where the range is potentially quite huge.

I am unsure about the intialView naming, another alternative I considered was startLevel, but I wanted to wait for your feedback.
