### PR TITLE
fix(types): fix return types to string

### DIFF
--- a/src/CalendarContext.tsx
+++ b/src/CalendarContext.tsx
@@ -15,7 +15,7 @@ export interface CalendarContextType extends DatePickerBaseProps {
   currentDate: DateType; // used for latest state of calendar based on Month and Year
   currentYear: number;
   setCalendarView: (value: CalendarViews) => void;
-  onSelectDate: (date: DateType) => void;
+  onSelectDate: (date: string) => void;
   onSelectMonth: (month: number) => void;
   onSelectYear: (year: number) => void;
   onChangeMonth: (value: number) => void;

--- a/src/DateTimePicker.tsx
+++ b/src/DateTimePicker.tsx
@@ -161,11 +161,9 @@ const DateTimePicker = (
 
   useEffect(() => {
     if (mode === 'single') {
-      const newDate = date && (timePicker ? date : date);
-
       dispatch({
         type: CalendarActionKind.CHANGE_SELECTED_DATE,
-        payload: { date: newDate },
+        payload: { date },
       });
     } else if (mode === 'range') {
       dispatch({
@@ -185,10 +183,12 @@ const DateTimePicker = (
   }, []);
 
   const onSelectDate = useCallback(
-    (date: DateType) => {
+    (selectedDate: string) => {
       if (onChange) {
         if (mode === 'single') {
-          const newDate = timePicker ? date : date.split(' ')[0];
+          const newDate = timePicker
+            ? selectedDate
+            : selectedDate.split(' ')[0];
 
           dispatch({
             type: CalendarActionKind.CHANGE_CURRENT_DATE,
@@ -203,17 +203,17 @@ const DateTimePicker = (
           const ed = state.endDate;
           let isStart: boolean = true;
 
-          if (sd && !ed && dateToUnix(date) >= dateToUnix(sd!)) {
+          if (sd && !ed && dateToUnix(selectedDate) >= dateToUnix(sd!)) {
             isStart = false;
           }
 
           (onChange as RangeChange)({
-            startDate: isStart ? getStartOfDay(date) : sd,
-            endDate: !isStart ? getEndOfDay(date) : undefined,
+            startDate: isStart ? getStartOfDay(selectedDate) : sd,
+            endDate: !isStart ? getEndOfDay(selectedDate) : undefined,
           });
         } else if (mode === 'multiple') {
           const safeDates = (state.dates as DateType[]) || [];
-          const newDate = getStartOfDay(date);
+          const newDate = getStartOfDay(selectedDate);
 
           const exists = safeDates.some((ed) => areDatesOnSameDay(ed, newDate));
 

--- a/src/DateTimePicker.tsx
+++ b/src/DateTimePicker.tsx
@@ -85,8 +85,6 @@ const DateTimePicker = (
   const initialCalendarView: CalendarViews =
     mode !== 'single' && initialView === 'time' ? 'day' : initialView;
 
-  console.log(initialCalendarView);
-
   const firstDay =
     firstDayOfWeek && firstDayOfWeek > 0 && firstDayOfWeek <= 6
       ? firstDayOfWeek
@@ -163,7 +161,7 @@ const DateTimePicker = (
 
   useEffect(() => {
     if (mode === 'single') {
-      const newDate = date && (timePicker ? date : getStartOfDay(date));
+      const newDate = date && (timePicker ? date : date);
 
       dispatch({
         type: CalendarActionKind.CHANGE_SELECTED_DATE,
@@ -190,7 +188,7 @@ const DateTimePicker = (
     (date: DateType) => {
       if (onChange) {
         if (mode === 'single') {
-          const newDate = timePicker ? date : getStartOfDay(date);
+          const newDate = timePicker ? date : date.split(' ')[0];
 
           dispatch({
             type: CalendarActionKind.CHANGE_CURRENT_DATE,

--- a/src/DateTimePicker.tsx
+++ b/src/DateTimePicker.tsx
@@ -188,7 +188,7 @@ const DateTimePicker = (
         if (mode === 'single') {
           const newDate = timePicker
             ? selectedDate
-            : selectedDate.split(' ')[0];
+            : (selectedDate.split(' ')[0] as string);
 
           dispatch({
             type: CalendarActionKind.CHANGE_CURRENT_DATE,

--- a/src/__tests__/api.test.tsx
+++ b/src/__tests__/api.test.tsx
@@ -25,6 +25,8 @@ describe('API TESTS', () => {
 
     expect(onChange).toHaveBeenCalledTimes(1);
     const call = onChange.mock.calls[0];
+
+    expect(typeof call[0].date).toEqual('string');
     expect(call[0].date).toEqual('2020-12-17');
   });
 
@@ -47,6 +49,7 @@ describe('API TESTS', () => {
 
     expect(onChange).toHaveBeenCalledTimes(1);
     const call = onChange.mock.calls[0];
+    expect(typeof call[0].date).toEqual('string');
     expect(call[0].date).toEqual('2020-12-17 12:30');
   });
 

--- a/src/__tests__/api.test.tsx
+++ b/src/__tests__/api.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react-native';
+import { render, screen, fireEvent } from '@testing-library/react-native';
 import DateTimePicker from '../DateTimePicker';
 //import dayjs from 'dayjs';
 import 'dayjs/locale/en';
@@ -9,14 +9,45 @@ import 'dayjs/locale/fr';
 import 'dayjs/locale/tr';
 
 describe('API TESTS', () => {
-  test('should display the passed date', () => {
+  test('should display the passed date', async () => {
     const selectedDate = new Date(2020, 11, 19);
     const month = selectedDate.toLocaleString('en-US', { month: 'long' });
+    onChange = jest.fn();
 
-    render(<DateTimePicker mode="single" date={selectedDate} />);
+    render(
+      <DateTimePicker mode="single" date={selectedDate} onChange={onChange} />
+    );
     expect(screen.getByText(month)).toBeVisible();
     expect(screen.getByText('19')).toBeVisible();
     expect(screen.getByText('2020')).toBeVisible();
+
+    await fireEvent.press(screen.getByText('17'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const call = onChange.mock.calls[0];
+    expect(call[0].date).toEqual('2020-12-17');
+  });
+
+  test('should display the passed date with time in time mode', async () => {
+    const selectedDate = new Date(2020, 11, 19, 12, 30);
+    const month = selectedDate.toLocaleString('en-US', { month: 'long' });
+    onChange = jest.fn();
+    render(
+      <DateTimePicker
+        timePicker={true}
+        date={selectedDate}
+        onChange={onChange}
+      />
+    );
+    expect(screen.getByText(month)).toBeVisible();
+    expect(screen.getByText('19')).toBeVisible();
+    expect(screen.getByText('2020')).toBeVisible();
+
+    await fireEvent.press(screen.getByText('17'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const call = onChange.mock.calls[0];
+    expect(call[0].date).toEqual('2020-12-17 12:30');
   });
 
   // test('minDate should be applied after init', () => {

--- a/src/__tests__/api.test.tsx
+++ b/src/__tests__/api.test.tsx
@@ -8,11 +8,11 @@ import 'dayjs/locale/es';
 import 'dayjs/locale/fr';
 import 'dayjs/locale/tr';
 
-describe('API TESTS', () => {
+describe('API Test Single Mode', () => {
   test('should display the passed date', async () => {
     const selectedDate = new Date(2020, 11, 19);
     const month = selectedDate.toLocaleString('en-US', { month: 'long' });
-    onChange = jest.fn();
+    const onChange = jest.fn();
 
     render(
       <DateTimePicker mode="single" date={selectedDate} onChange={onChange} />
@@ -33,9 +33,10 @@ describe('API TESTS', () => {
   test('should display the passed date with time in time mode', async () => {
     const selectedDate = new Date(2020, 11, 19, 12, 30);
     const month = selectedDate.toLocaleString('en-US', { month: 'long' });
-    onChange = jest.fn();
+    const onChange = jest.fn();
     render(
       <DateTimePicker
+        mode="single"
         timePicker={true}
         date={selectedDate}
         onChange={onChange}

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,9 @@ export interface IDayObject {
   rightCrop: boolean;
 }
 
-export type SingleChange = (params: { date: DateType }) => void;
+// Returns the date in the format of 'YYYY-MM-DD' for date only mode
+// Returns the date in the format of 'YYYY-MM-DD HH:mm' for date and time mode
+export type SingleChange = (params: { date: string }) => void;
 
 export type RangeChange = (params: {
   startDate: DateType;


### PR DESCRIPTION
This cleans up the return type to be a string. 
As the time containing already was a string this provides the same type for both possible return types.

Returning a date leads to problems when selecting dates with the current timezone which can end up returning the day before the selected date.

