### PR TITLE
Update Header.tsx - Fixing year.at(0) error on selecting the year in the Calender

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -104,7 +104,7 @@ const Header = ({ buttonPrevIcon, buttonNextIcon }: HeaderProps) => {
         <View style={[styles.textContainer, theme?.headerTextContainerStyle]}>
           <Text style={[styles.text, theme?.headerTextStyle]}>
             {calendarView === 'year'
-              ? `${years.at(0)} - ${years.at(-1)}`
+              ? `${years[0]} - ${years[years.length-1]}`
               : dayjs(currentDate).format('YYYY')}
           </Text>
         </View>


### PR DESCRIPTION
Fixing year.at(0) error on selecting the year in the Calender

```typescript
TypeError: years.at is not a function. (In 'years.at(0)', 'years.at' is undefined)
``` 
![image](https://github.com/farhoudshapouran/react-native-ui-datepicker/assets/34683195/fa1c547d-c4bd-486d-b680-fd5f18b834e2)

was getting the above error on selecting the year