### PR TITLE
Fix: set min date as first date to show when available

### DIFF
--- a/src/DateTimePicker.tsx
+++ b/src/DateTimePicker.tsx
@@ -105,6 +105,10 @@ const DateTimePicker = (
     currentDate = dayjs(dates[0]);
   }
 
+  if (minDate && currentDate.isBefore(minDate)) {
+    currentDate = dayjs(minDate);
+  }
+
   let currentYear = currentDate.year();
 
   dayjs.locale(locale);
@@ -162,7 +166,8 @@ const DateTimePicker = (
 
   useEffect(() => {
     if (mode === 'single') {
-      const newDate = date && (timePicker ? date : getStartOfDay(date));
+      const newDate =
+        (date && (timePicker ? date : getStartOfDay(date))) ?? minDate;
 
       dispatch({
         type: CalendarActionKind.CHANGE_SELECTED_DATE,
@@ -179,7 +184,7 @@ const DateTimePicker = (
         payload: { dates },
       });
     }
-  }, [mode, date, startDate, endDate, dates, timePicker]);
+  }, [mode, date, startDate, endDate, dates, minDate, timePicker]);
 
   const setCalendarView = useCallback((view: CalendarViews) => {
     dispatch({ type: CalendarActionKind.SET_CALENDAR_VIEW, payload: view });


### PR DESCRIPTION
Set the min date as current date, otherwise when you pick a min date in the next month - it will show disabled dates for the whole month.

example: min date set to 03.07.2024 and current date is 05.06.2024

<img width="398" alt="Screenshot 2024-06-05 at 14 31 05" src="https://github.com/farhoudshapouran/react-native-ui-datepicker/assets/34455555/9aa726b6-9d15-47b3-bc44-aa2c9adac140">
