### PR TITLE
feat(disable): allow week days to be removed from selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,17 +59,16 @@ For more, take a look at the `/example` directory.
 
 ## Calendar props
 
-| Name            | Type           | Default       | Description                                                               |
-| --------------- | -------------- | ------------- | ------------------------------------------------------------------------- |
-| mode            | `string`       | `'single'`    | Defines the DatePicker mode `['single', 'range', 'multiple']`             |
-| locale          | `string`       | `'en'`        | Defines the DatePicker locale                                             |
-| minDate         | `DateType`     | `null`        | Defines DatePicker minimum selectable date                                |
-| maxDate         | `DateType`     | `null`        | Defines DatePicker maximum selectable date                                |
-| disabledDays    | `DisabledDays` | `'undefined'` | Defines DatePicker disabled weekdays (e.g., disable Sunday from selection)|
-| firstDayOfWeek  | `number`       | `0`           | Defines the starting day of week, number 0-6, 0 - Sunday, 6 - Saturday    |
-| displayFullDays | `boolean`      | `false`       | Defines show previous and next month's days in the current calendar view  |
-| initialView     | `string`       | `'day'`       | Defines the DatePicker initial view `['day', 'month', 'year', 'time']`    |
-| height          | `number`       | `'undefined'` | Defines the Calendar view heights                                         |
+| Name            | Type       | Default       | Description                                                              |
+| --------------- | ---------- | ------------- | ------------------------------------------------------------------------ |
+| mode            | `string`   | `'single'`    | Defines the DatePicker mode `['single', 'range', 'multiple']`            |
+| locale          | `string`   | `'en'`        | Defines the DatePicker locale                                            |
+| minDate         | `DateType` | `null`        | Defines DatePicker minimum selectable date                               |
+| maxDate         | `DateType` | `null`        | Defines DatePicker maximum selectable date                               |
+| firstDayOfWeek  | `number`   | `0`           | Defines the starting day of week, number 0-6, 0 - Sunday, 6 - Saturday   |
+| displayFullDays | `boolean`  | `false`       | Defines show previous and next month's days in the current calendar view |
+| initialView     | `string`   | `'day'`       | Defines the DatePicker initial view `['day', 'month', 'year', 'time']`   |
+| height          | `number`   | `'undefined'` | Defines the Calendar view heights                                        |
 
 <p align="center">
 <img src="/.github/images/modes-screenshot.png" />
@@ -77,11 +76,12 @@ For more, take a look at the `/example` directory.
 
 ## Single Mode props
 
-| Name       | Type       | Default          | Description                                       |
-| ---------- | ---------- | ---------------- | ------------------------------------------------- |
-| date       | `DateType` | `undefined`      | Date value to display selected date               |
-| onChange   | `Function` | `({date}) => {}` | Called when the new date selected from DatePicker |
-| timePicker | `boolean`  | `false`          | Defines show or hide time picker                  |
+| Name         | Type           | Default          | Description                                                                |
+| ------------ | -------------- | ---------------- | -------------------------------------------------------------------------- |
+| date         | `DateType`     | `undefined`      | Date value to display selected date                                        |
+| onChange     | `Function`     | `({date}) => {}` | Called when the new date selected from DatePicker                          |
+| timePicker   | `boolean`      | `false`          | Defines show or hide time picker                                           |
+| disabledDays | `DisabledDays` | `'undefined'`    | Defines DatePicker disabled weekdays (e.g., disable Sunday from selection) |
 
 ## Range Mode props
 

--- a/README.md
+++ b/README.md
@@ -59,16 +59,17 @@ For more, take a look at the `/example` directory.
 
 ## Calendar props
 
-| Name            | Type       | Default       | Description                                                              |
-| --------------- | ---------- | ------------- | ------------------------------------------------------------------------ |
-| mode            | `string`   | `'single'`    | Defines the DatePicker mode `['single', 'range', 'multiple']`            |
-| locale          | `string`   | `'en'`        | Defines the DatePicker locale                                            |
-| minDate         | `DateType` | `null`        | Defines DatePicker minimum selectable date                               |
-| maxDate         | `DateType` | `null`        | Defines DatePicker maximum selectable date                               |
-| firstDayOfWeek  | `number`   | `0`           | Defines the starting day of week, number 0-6, 0 - Sunday, 6 - Saturday   |
-| displayFullDays | `boolean`  | `false`       | Defines show previous and next month's days in the current calendar view |
-| initialView     | `string`   | `'day'`       | Defines the DatePicker initial view `['day', 'month', 'year', 'time']`   |
-| height          | `number`   | `'undefined'` | Defines the Calendar view heights                                        |
+| Name            | Type           | Default       | Description                                                               |
+| --------------- | -------------- | ------------- | ------------------------------------------------------------------------- |
+| mode            | `string`       | `'single'`    | Defines the DatePicker mode `['single', 'range', 'multiple']`             |
+| locale          | `string`       | `'en'`        | Defines the DatePicker locale                                             |
+| minDate         | `DateType`     | `null`        | Defines DatePicker minimum selectable date                                |
+| maxDate         | `DateType`     | `null`        | Defines DatePicker maximum selectable date                                |
+| disabledDays    | `DisabledDays` | `'undefined'` | Defines DatePicker disabled weekdays (e.g., disable Sunday from selection)|
+| firstDayOfWeek  | `number`       | `0`           | Defines the starting day of week, number 0-6, 0 - Sunday, 6 - Saturday    |
+| displayFullDays | `boolean`      | `false`       | Defines show previous and next month's days in the current calendar view  |
+| initialView     | `string`       | `'day'`       | Defines the DatePicker initial view `['day', 'month', 'year', 'time']`    |
+| height          | `number`       | `'undefined'` | Defines the Calendar view heights                                         |
 
 <p align="center">
 <img src="/.github/images/modes-screenshot.png" />

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -190,6 +190,7 @@ export default function App() {
               startDate={range.startDate}
               endDate={range.endDate}
               dates={dates}
+              //disabledDays={{ sunday: true, saturday: true }}
               //minDate={dayjs().startOf('day')}
               //maxDate={dayjs().add(3, 'day').endOf('day')}
               //firstDayOfWeek={1}

--- a/src/CalendarContext.tsx
+++ b/src/CalendarContext.tsx
@@ -4,6 +4,7 @@ import type {
   DateType,
   DatePickerBaseProps,
   CalendarThemeProps,
+  DisabledDays,
 } from './types';
 
 export interface CalendarContextType extends DatePickerBaseProps {
@@ -14,6 +15,7 @@ export interface CalendarContextType extends DatePickerBaseProps {
   calendarView: CalendarViews;
   currentDate: DateType; // used for latest state of calendar based on Month and Year
   currentYear: number;
+  disabledDays?: DisabledDays;
   setCalendarView: (value: CalendarViews) => void;
   onSelectDate: (date: DateType) => void;
   onSelectMonth: (month: number) => void;

--- a/src/DateTimePicker.tsx
+++ b/src/DateTimePicker.tsx
@@ -80,6 +80,7 @@ const DateTimePicker = (
     onChange,
     initialView = 'day',
     height,
+    disabledDays,
     ...rest
   } = props;
 
@@ -302,6 +303,7 @@ const DateTimePicker = (
         onSelectYear,
         onChangeMonth,
         onChangeYear,
+        disabledDays,
       }}
     >
       <Calendar

--- a/src/DateTimePicker.tsx
+++ b/src/DateTimePicker.tsx
@@ -19,6 +19,7 @@ import type {
   SingleChange,
   RangeChange,
   MultiChange,
+  DisabledDays,
 } from './types';
 import Calendar from './components/Calendar';
 import dayjs from 'dayjs';
@@ -37,6 +38,7 @@ export interface DatePickerSingleProps
   mode: 'single';
   date?: DateType;
   onChange?: SingleChange;
+  disabledDays?: DisabledDays;
 }
 
 export interface DatePickerRangeProps
@@ -80,7 +82,7 @@ const DateTimePicker = (
     onChange,
     initialView = 'day',
     height,
-    disabledDays,
+    disabledDays = {},
     ...rest
   } = props;
 

--- a/src/__tests__/api.test.tsx
+++ b/src/__tests__/api.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react-native';
+import { fireEvent, render, screen } from '@testing-library/react-native';
 import DateTimePicker from '../DateTimePicker';
 //import dayjs from 'dayjs';
 import 'dayjs/locale/en';
@@ -17,6 +17,24 @@ describe('API TESTS', () => {
     expect(screen.getByText(month)).toBeVisible();
     expect(screen.getByText('19')).toBeVisible();
     expect(screen.getByText('2020')).toBeVisible();
+  });
+
+  test('should not allow disabled weekdays to be selected', () => {
+    const selectedDate = new Date(2020, 11, 15); // Start with Tuesday
+    const changeFn = jest.fn();
+
+    render(
+      <DateTimePicker
+        mode="single"
+        date={selectedDate}
+        onChange={changeFn}
+        disabledDays={{ monday: true }}
+      />
+    );
+
+    // 14th is Monday
+    fireEvent.press(screen.getByText('14'));
+    expect(changeFn).not.toHaveBeenCalled();
   });
 
   // test('minDate should be applied after init', () => {

--- a/src/components/Day.tsx
+++ b/src/components/Day.tsx
@@ -88,7 +88,7 @@ function Day({
       {inRange && !isCrop ? (
         <View
           style={[style.rangeRoot, { backgroundColor: rangeRootBackground }]}
-        ></View>
+        />
       ) : null}
 
       {isCrop && leftCrop ? (
@@ -100,7 +100,7 @@ function Day({
               backgroundColor: rangeRootBackground,
             },
           ]}
-        ></View>
+        />
       ) : null}
 
       {isCrop && rightCrop ? (
@@ -112,7 +112,7 @@ function Day({
               backgroundColor: rangeRootBackground,
             },
           ]}
-        ></View>
+        />
       ) : null}
 
       <Pressable

--- a/src/components/DaySelector.tsx
+++ b/src/components/DaySelector.tsx
@@ -28,6 +28,7 @@ const DaySelector = () => {
     maxDate,
     firstDayOfWeek,
     theme,
+    disabledDays,
     height,
   } = useCalendarContext();
 
@@ -48,7 +49,8 @@ const DaySelector = () => {
         displayFullDays,
         minDate,
         maxDate,
-        firstDayOfWeek
+        firstDayOfWeek,
+        disabledDays
       ).map((day, index) => {
         if (day) {
           let leftCrop = day.dayOfMonth === 1;

--- a/src/components/DaySelector.tsx
+++ b/src/components/DaySelector.tsx
@@ -50,7 +50,7 @@ const DaySelector = () => {
         minDate,
         maxDate,
         firstDayOfWeek,
-        disabledDays
+        mode === 'single' ? disabledDays : {}
       ).map((day, index) => {
         if (day) {
           let leftCrop = day.dayOfMonth === 1;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -104,7 +104,7 @@ const Header = ({ buttonPrevIcon, buttonNextIcon }: HeaderProps) => {
         <View style={[styles.textContainer, theme?.headerTextContainerStyle]}>
           <Text style={[styles.text, theme?.headerTextStyle]}>
             {calendarView === 'year'
-              ? `${years[0]} - ${years[years.length-1]}`
+              ? `${years[0]} - ${years[years.length - 1]}`
               : dayjs(currentDate).format('YYYY')}
           </Text>
         </View>

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,16 @@ export type LocalState = {
   currentYear: number;
 };
 
+export type DisabledDays = {
+  monday?: boolean;
+  tuesday?: boolean;
+  wednesday?: boolean;
+  thursday?: boolean;
+  friday?: boolean;
+  saturday?: boolean;
+  sunday?: boolean;
+};
+
 export type CalendarAction = {
   type: CalendarActionKind;
   payload: any;
@@ -95,4 +105,5 @@ export interface DatePickerBaseProps {
   onChange?: SingleChange | RangeChange | MultiChange;
   initialView?: CalendarViews;
   height?: number;
+  disabledDays?: DisabledDays;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,18 @@
 import dayjs from 'dayjs';
-import type { DateType, IDayObject } from './types';
+import type { DateType, DisabledDays, IDayObject } from './types';
 
 export const CALENDAR_FORMAT = 'YYYY-MM-DD HH:mm';
 export const DATE_FORMAT = 'YYYY-MM-DD';
 export const YEAR_PAGE_SIZE = 12;
+export const WEEK_DAYS = [
+  'sunday',
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+];
 
 export const getMonths = () => dayjs.months();
 
@@ -158,7 +167,8 @@ export const getMonthDays = (
   displayFullDays: boolean,
   minDate: DateType,
   maxDate: DateType,
-  firstDayOfWeek: number
+  firstDayOfWeek: number,
+  disabledDays?: DisabledDays
 ): IDayObject[] => {
   const date = getDate(datetime);
   const {
@@ -178,7 +188,8 @@ export const getMonthDays = (
           minDate,
           maxDate,
           false,
-          index + 1
+          index + 1,
+          disabledDays
         );
       })
     : Array(prevMonthOffset).fill(null);
@@ -192,7 +203,8 @@ export const getMonthDays = (
       minDate,
       maxDate,
       true,
-      prevMonthOffset + day
+      prevMonthOffset + day,
+      disabledDays
     );
   });
 
@@ -205,7 +217,8 @@ export const getMonthDays = (
       minDate,
       maxDate,
       false,
-      daysInCurrentMonth + prevMonthOffset + day
+      daysInCurrentMonth + prevMonthOffset + day,
+      disabledDays
     );
   });
 
@@ -229,7 +242,8 @@ const generateDayObject = (
   minDate: DateType,
   maxDate: DateType,
   isCurrentMonth: boolean,
-  dayOfMonth: number
+  dayOfMonth: number,
+  disabledDays?: DisabledDays
 ) => {
   let disabled = false;
   if (minDate) {
@@ -238,6 +252,12 @@ const generateDayObject = (
   if (maxDate && !disabled) {
     disabled = date > getDate(maxDate);
   }
+
+  const weekDay = getWeekdayName(date.toDate()) as keyof DisabledDays;
+  if (weekDay && disabledDays?.[weekDay]) {
+    disabled = true;
+  }
+
   return {
     text: day.toString(),
     day: day,
@@ -268,4 +288,9 @@ export function addColorAlpha(color: string | undefined, opacity: number) {
   }
 
   return color + opacityHex;
+}
+
+export function getWeekdayName(date: Date): string | undefined {
+  const dayIndex = date.getDay();
+  return WEEK_DAYS[dayIndex];
 }


### PR DESCRIPTION
## Allowing Weekdays to Be Disabled from Selection

Sometimes we'll want to prevent users from selecting specific weekdays, for example, weekend days. By using disabledDays, we can disable specific days based on any external rules.

It seems to be a useful feature, so I wanted to open this PR. If it makes sense, feel free to merge 🙌🏼 
**I appreciate your time in developing this cross-platform library. Keep up the great work!**

If something is not good, I'm also open to adjusting it so we can merge the feature 👍🏼

## Demo ( disabled Saturday & Sunday )
![image](https://github.com/farhoudshapouran/react-native-ui-datepicker/assets/11210923/c6cfbf94-56f4-4bc2-8702-e4a61ef1c5a8)
