### PR TITLE
fix: styles of startDate and endDate on range mode

### DIFF
--- a/src/components/Day.tsx
+++ b/src/components/Day.tsx
@@ -98,8 +98,10 @@ function Day({
           style={[
             style.rangeRoot,
             {
-              left: '50%',
+              left: 0,
               backgroundColor: rangeRootBackground,
+              borderTopLeftRadius: 100,
+              borderBottomLeftRadius: 100,
             },
           ]}
         ></View>
@@ -110,8 +112,10 @@ function Day({
           style={[
             style.rangeRoot,
             {
-              right: '50%',
+              right: 0,
               backgroundColor: rangeRootBackground,
+              borderTopRightRadius: 100,
+              borderBottomRightRadius: 100,
             },
           ]}
         ></View>


### PR DESCRIPTION
fix styles mentioned by [@jtsimoes](https://github.com/jtsimoes) on https://github.com/farhoudshapouran/react-native-ui-datepicker/pull/92#issuecomment-2347020944