### PR TITLE
Fix: allow switching between years when using months selector

### DIFF
--- a/src/DateTimePicker.tsx
+++ b/src/DateTimePicker.tsx
@@ -6,6 +6,7 @@ import {
   getEndOfDay,
   getStartOfDay,
   areDatesOnSameDay,
+  getFirstDayOfYear,
 } from './utils';
 import CalendarContext from './CalendarContext';
 import { CalendarViews, CalendarActionKind } from './enums';
@@ -243,7 +244,7 @@ const DateTimePicker = (
 
   const onSelectMonth = useCallback(
     (month: number) => {
-      const newDate = getDate(state.currentDate).month(month);
+      const newDate = getFirstDayOfYear(state.currentYear).month(month);
       dispatch({
         type: CalendarActionKind.CHANGE_CURRENT_DATE,
         payload: getFormated(newDate),
@@ -253,7 +254,7 @@ const DateTimePicker = (
         payload: 'day',
       });
     },
-    [state.currentDate]
+    [state.currentYear]
   );
 
   const onSelectYear = useCallback(

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,12 @@ import { View, Text, Pressable, StyleSheet, Image } from 'react-native';
 import { useCalendarContext } from '../CalendarContext';
 import dayjs from 'dayjs';
 import type { HeaderProps } from '../types';
-import { getDateYear, getYearRange, YEAR_PAGE_SIZE } from '../utils';
+import {
+  getDateYear,
+  getFirstDayOfYear,
+  getYearRange,
+  YEAR_PAGE_SIZE,
+} from '../utils';
 
 const arrow_left = require('../assets/images/arrow_left.png');
 const arrow_right = require('../assets/images/arrow_right.png');
@@ -89,6 +94,22 @@ const Header = ({ buttonPrevIcon, buttonNextIcon }: HeaderProps) => {
     </Pressable>
   );
 
+  const monthListSelector = useCallback(() => {
+    const label = getFirstDayOfYear(currentYear).format('YYYY');
+    return (
+      <Pressable
+        onPress={() => setCalendarView('year')}
+        testID="btn-month"
+        accessibilityRole="button"
+        accessibilityLabel={label}
+      >
+        <View style={[styles.textContainer, theme?.headerTextContainerStyle]}>
+          <Text style={[styles.text, theme?.headerTextStyle]}>{label}</Text>
+        </View>
+      </Pressable>
+    );
+  }, [currentYear, setCalendarView, theme]);
+
   const yearSelector = useCallback(() => {
     const years = getYearRange(currentYear);
     return (
@@ -139,9 +160,16 @@ const Header = ({ buttonPrevIcon, buttonNextIcon }: HeaderProps) => {
   const renderSelectors = (
     <>
       <View style={styles.selectorContainer}>
-        {calendarView !== 'year' ? monthSelector : null}
-        {yearSelector()}
+        {calendarView === 'month' ? (
+          monthListSelector()
+        ) : (
+          <>
+            {calendarView !== 'year' ? monthSelector : null}
+            {yearSelector()}
+          </>
+        )}
       </View>
+
       {timePicker && mode === 'single' && calendarView !== 'year' ? (
         <Pressable
           onPress={() =>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -135,6 +135,10 @@ export function getDaysInMonth(
   };
 }
 
+export function getFirstDayOfYear(year: number) {
+  return dayjs().set('year', year).startOf('year');
+}
+
 export function getFirstDayOfMonth(
   date: DateType,
   firstDayOfWeek: number


### PR DESCRIPTION
## Context

The current `month` calendar view does not allow using arrows to switch between years. At least, the UI is not updated leading users to fix that it's not working.

With this PR, we use a different header label when displaying the `month` calendar view to show the current year.
When choosing a month, we now land on the right month of the right year.

| Before | After |
|-------|-------|
| https://github.com/user-attachments/assets/6b35f7d4-faf6-4efa-819e-1b762b9d0d09 | https://github.com/user-attachments/assets/25975ffd-fd83-4065-8340-2fe59d534d00 |



