### PR TITLE
Add RTL Support to `TimeSelector` Component

### DIFF
--- a/src/components/TimeSelector.tsx
+++ b/src/components/TimeSelector.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Text, View, StyleSheet } from 'react-native';
+import { Text, View, StyleSheet, I18nManager } from 'react-native';
 import { useCalendarContext } from '../CalendarContext';
 import Wheel from './TimePicker/Wheel';
 import { CALENDAR_HEIGHT } from '../enums';
@@ -69,7 +69,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   timePickerContainer: {
-    flexDirection: 'row',
+    flexDirection: I18nManager.getConstants().isRTL ? 'row-reverse' : 'row',
     alignItems: 'center',
     justifyContent: 'center',
     width: CALENDAR_HEIGHT / 2,


### PR DESCRIPTION
# Add RTL Support to `TimeSelector` Component

## Description
This PR introduces support for right-to-left (RTL) layouts in the `TimeSelector` component of the library. The `flexDirection` of the `timePickerContainer` style now dynamically adapts based on the current RTL setting, ensuring proper alignment for RTL users.

## Changes
- Imported `I18nManager` from `react-native`.
- Updated the `timePickerContainer` style to set `flexDirection` dynamically:
  - `row-reverse` for RTL layouts.
  - `row` for LTR layouts.

## Benefits
- Improves accessibility and user experience for RTL language users by properly aligning the component's layout.

## Testing
- Verified the component's behavior in both RTL (`I18nManager.forceRTL(true)`) and LTR modes.
- Confirmed that the alignment and layout are correct in each case.

## Breaking Changes
- None. This change is backward-compatible with existing LTR layouts.

