### PR TITLE
Feat: enable 12 hour time format

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,12 @@ export function Calendar() {
 
 ## Single Mode props
 
-| Name         | Type               | Description                                         |
-| ------------ | ------------------ | --------------------------------------------------- |
-| `date`       | `DateType`         | Specifies the currently selected date.              |
-| `onChange`   | `({date}) => void` | Callback function triggered when the date change.   |
-| `timePicker` | `boolean`          | Whether to enable the time picker.                  |
+| Name         | Type               | Description                                                   |
+| ------------ | ------------------ | ------------------------------------------------------------- |
+| `date`       | `DateType`         | Specifies the currently selected date.                        |
+| `onChange`   | `({date}) => void` | Callback function triggered when the date change.             |
+| `timePicker` | `boolean`          | Whether to enable the time picker.                            |
+| `use12Hours` | `boolean`          | Whether to use a 12-hour format (AM/PM) in the time picker.   |
 
 ## Range Mode props
 

--- a/demo/components/examples/single-datepicker.tsx
+++ b/demo/components/examples/single-datepicker.tsx
@@ -14,8 +14,9 @@ export default function SingleDatePicker() {
         date={date}
         onChange={({ date }) => setDate(date)}
         timePicker
-        // minDate={new Date()}
-        // maxDate={new Date(new Date().getFullYear(), 11, 31)} // end of the year
+        //use12Hours
+        //minDate={new Date()}
+        //maxDate={new Date(new Date().getFullYear(), 11, 31)} // end of the year
       />
       <DateInput
         value={date ? dayjs(date).format('MMMM DD, YYYY HH:mm') : null}

--- a/src/components/header/time-button.tsx
+++ b/src/components/header/time-button.tsx
@@ -14,26 +14,29 @@ export const TimeButton = () => {
     styles,
     classNames,
     numerals = 'latn',
+    use12Hours,
   } = useCalendarContext();
 
-  const { hour, minute } = useMemo(
+  const { hour, hour12, minute, period } = useMemo(
     () => getParsedDate(date || currentDate),
     [date, currentDate]
   );
 
   const labelText = useMemo(() => {
+    const hourValue = use12Hours ? hour12 : hour;
+
     const hourLabel =
-      hour < 10
-        ? `${formatNumber(0, numerals)}${formatNumber(hour, numerals)}`
-        : `${formatNumber(hour, numerals)}`;
+      hourValue < 10
+        ? `${formatNumber(0, numerals)}${formatNumber(hourValue, numerals)}`
+        : `${formatNumber(hourValue, numerals)}`;
 
     const minuteLabel =
       minute < 10
         ? `${formatNumber(0, numerals)}${formatNumber(minute, numerals)}`
         : `${formatNumber(minute, numerals)}`;
 
-    return `${hourLabel}:${minuteLabel}`;
-  }, [numerals, hour, minute]);
+    return `${hourLabel}:${minuteLabel} ${use12Hours ? period : ''}`.trim();
+  }, [numerals, hour, hour12, minute, use12Hours, period]);
 
   return (
     <Pressable

--- a/src/components/time-picker.tsx
+++ b/src/components/time-picker.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   View,
   StyleSheet,
@@ -7,6 +7,7 @@ import {
   TextStyle,
   ScrollView,
   Text,
+  Pressable,
 } from 'react-native';
 import { useCalendarContext } from '../calendar-context';
 import Wheel from './time-picker/wheel';
@@ -20,13 +21,17 @@ export type Time = {
   text: string;
 };
 
-const createNumberList = (num: number, numerals: Numerals): Time[] => {
+const createNumberList = (
+  num: number,
+  numerals: Numerals,
+  startFrom: number = 0
+): Time[] => {
   return Array.from({ length: num }, (_, i) => ({
-    value: i,
+    value: i + startFrom,
     text:
-      i < 10
-        ? `${formatNumber(0, numerals)}${formatNumber(i, numerals)}`
-        : `${formatNumber(i, numerals)}`,
+      i + startFrom < 10
+        ? `${formatNumber(0, numerals)}${formatNumber(i + startFrom, numerals)}`
+        : `${formatNumber(i + startFrom, numerals)}`,
   }));
 };
 
@@ -41,20 +46,40 @@ const TimePicker = () => {
     numerals = 'latn',
   } = useCalendarContext();
 
-  const hours = useMemo(() => createNumberList(24, numerals), [numerals]);
+  const is12Hour = true;
+
+  const hours = useMemo(
+    () => createNumberList(is12Hour ? 12 : 24, numerals, is12Hour ? 1 : 0),
+    [numerals, is12Hour]
+  );
   const minutes = useMemo(() => createNumberList(60, numerals), [numerals]);
 
-  const { hour, minute } = useMemo(
+  const { hour: currentHour, minute } = useMemo(
     () => getParsedDate(date || currentDate),
     [date, currentDate]
   );
 
+  // Determine initial AM/PM state based on hour
+  const initialPeriod = currentHour >= 12 ? 'PM' : 'AM';
+
+  // Set up state for AM/PM
+  const [period, setPeriod] = useState(initialPeriod);
+
   const handleChangeHour = useCallback(
     (value: number) => {
-      const newDate = dayjs.tz(date, timeZone).hour(value);
+      let hour24 = value;
+
+      if (is12Hour) {
+        if (period === 'PM' && value < 12) {
+          hour24 = value + 12;
+        } else if (period === 'AM' && value === 12) {
+          hour24 = 0;
+        }
+      }
+      const newDate = dayjs.tz(date, timeZone).hour(hour24);
       onSelectDate(newDate);
     },
-    [date, onSelectDate, timeZone]
+    [date, onSelectDate, timeZone, is12Hour, period]
   );
 
   const handleChangeMinute = useCallback(
@@ -63,6 +88,29 @@ const TimePicker = () => {
       onSelectDate(newDate);
     },
     [date, onSelectDate, timeZone]
+  );
+
+  // Convert to 12-hour format for wheel display
+  const currentHour12 = currentHour % 12 === 0 ? 12 : currentHour % 12;
+
+  const handlePeriodChange = useCallback(
+    (newPeriod: 'AM' | 'PM') => {
+      setPeriod(newPeriod);
+
+      // Convert to 24-hour and update date
+      let newHour = currentHour12;
+      if (newPeriod === 'PM' && currentHour12 < 12) {
+        newHour = currentHour12 + 12;
+      } else if (newPeriod === 'AM' && currentHour12 === 12) {
+        newHour = 0;
+      } else if (newPeriod === 'AM' && currentHour >= 12) {
+        newHour = currentHour12;
+      }
+
+      const newDate = dayjs.tz(date || currentDate, timeZone).hour(newHour);
+      onSelectDate(newDate);
+    },
+    [date, currentDate, onSelectDate, timeZone, currentHour12]
   );
 
   const timePickerContainerStyle: ViewStyle = useMemo(
@@ -88,7 +136,7 @@ const TimePicker = () => {
       <View style={timePickerContainerStyle}>
         <View style={defaultStyles.wheelContainer}>
           <Wheel
-            value={hour}
+            value={currentHour12}
             items={hours}
             setValue={handleChangeHour}
             styles={styles}
@@ -107,6 +155,20 @@ const TimePicker = () => {
             classNames={classNames}
           />
         </View>
+      </View>
+      <View style={defaultStyles.periodContainer}>
+        <Pressable
+          onPress={() => handlePeriodChange(period == 'AM' ? 'PM' : 'AM')}
+        >
+          <View
+            style={[defaultStyles.period, styles?.time_selected_indicator]}
+            className={classNames?.time_selected_indicator}
+          >
+            <Text style={styles?.time_label} className={classNames?.time_label}>
+              {period}
+            </Text>
+          </View>
+        </Pressable>
       </View>
     </ScrollView>
   );
@@ -129,6 +191,15 @@ const defaultStyles = StyleSheet.create({
   },
   timeSeparator: {
     marginHorizontal: 5,
+  },
+  periodContainer: {
+    marginLeft: 10,
+  },
+  period: {
+    width: 65,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });
 

--- a/src/components/time-picker/period-native.tsx
+++ b/src/components/time-picker/period-native.tsx
@@ -1,0 +1,53 @@
+import { memo } from 'react';
+import WheelPicker from './wheel-picker';
+import { ClassNames, PickerOption, Styles } from '../../types';
+import { isEqual } from 'lodash';
+
+interface PeriodProps {
+  value: string;
+  setValue?: (value: any) => void;
+  styles?: Styles;
+  classNames?: ClassNames;
+}
+
+const options: PickerOption[] = [
+  { value: 'AM', text: 'AM' },
+  { value: 'PM', text: 'PM' },
+];
+
+const PeriodNative = ({
+  value,
+  setValue = () => {},
+  styles,
+  classNames,
+}: PeriodProps) => {
+  return (
+    <WheelPicker
+      value={value}
+      options={options}
+      onChange={setValue}
+      //containerStyle={defaultStyles.container}
+      itemTextStyle={styles?.time_label}
+      itemTextClassName={classNames?.time_label}
+      selectedIndicatorClassName={classNames?.time_selected_indicator}
+      selectedIndicatorStyle={styles?.time_selected_indicator}
+      itemHeight={44}
+      decelerationRate="fast"
+    />
+  );
+};
+
+const customComparator = (
+  prev: Readonly<PeriodProps>,
+  next: Readonly<PeriodProps>
+) => {
+  const areEqual =
+    prev.value === next.value &&
+    prev.setValue === next.setValue &&
+    isEqual(prev.styles, next.styles) &&
+    isEqual(prev.classNames, next.classNames);
+
+  return areEqual;
+};
+
+export default memo(PeriodNative, customComparator);

--- a/src/components/time-picker/period-picker.tsx
+++ b/src/components/time-picker/period-picker.tsx
@@ -1,0 +1,19 @@
+import React, { memo } from 'react';
+import { Platform } from 'react-native';
+import PeriodNative from './period-native';
+import PeriodWeb from './period-web';
+import { ClassNames, Styles } from '../../types';
+
+type PeriodProps = {
+  value: string;
+  setValue?: (value: any) => void;
+  styles?: Styles;
+  classNames?: ClassNames;
+};
+
+const PeriodPicker = (props: PeriodProps) => {
+  const Component = Platform.OS === 'web' ? PeriodWeb : PeriodNative;
+  return <Component {...props} />;
+};
+
+export default memo(PeriodPicker);

--- a/src/components/time-picker/period-web.tsx
+++ b/src/components/time-picker/period-web.tsx
@@ -1,0 +1,55 @@
+import { memo } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { ClassNames, Styles } from '../../types';
+import { isEqual } from 'lodash';
+
+interface PeriodProps {
+  value: string;
+  setValue?: (value: any) => void;
+  styles?: Styles;
+  classNames?: ClassNames;
+}
+
+const PeriodWeb = ({
+  value,
+  setValue = () => {},
+  styles,
+  classNames,
+}: PeriodProps) => {
+  return (
+    <Pressable onPress={() => setValue(value == 'AM' ? 'PM' : 'AM')}>
+      <View
+        style={[defaultStyles.period, styles?.time_selected_indicator]}
+        className={classNames?.time_selected_indicator}
+      >
+        <Text style={styles?.time_label} className={classNames?.time_label}>
+          {value}
+        </Text>
+      </View>
+    </Pressable>
+  );
+};
+
+const defaultStyles = StyleSheet.create({
+  period: {
+    width: 65,
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+const customComparator = (
+  prev: Readonly<PeriodProps>,
+  next: Readonly<PeriodProps>
+) => {
+  const areEqual =
+    prev.value === next.value &&
+    prev.setValue === next.setValue &&
+    isEqual(prev.styles, next.styles) &&
+    isEqual(prev.classNames, next.classNames);
+
+  return areEqual;
+};
+
+export default memo(PeriodWeb, customComparator);

--- a/src/components/time-picker/wheel-native.tsx
+++ b/src/components/time-picker/wheel-native.tsx
@@ -1,13 +1,12 @@
 import React, { memo } from 'react';
 import { StyleSheet, Platform } from 'react-native';
 import WheelPicker from './wheel-picker';
-import { ClassNames, Styles } from '../../types';
-import { Time } from '../time-picker';
+import { ClassNames, PickerOption, Styles } from '../../types';
 
 interface WheelProps {
-  value: number;
-  setValue?: (value: number) => void;
-  items: Time[];
+  value: number | string;
+  setValue?: (value: any) => void;
+  items: PickerOption[];
   styles?: Styles;
   classNames?: ClassNames;
 }
@@ -21,7 +20,7 @@ const WheelNative = ({
 }: WheelProps) => {
   return (
     <WheelPicker
-      selectedIndex={value}
+      value={value}
       options={items}
       onChange={setValue}
       containerStyle={defaultStyles.container}

--- a/src/components/time-picker/wheel-picker/wheel-picker-item.tsx
+++ b/src/components/time-picker/wheel-picker/wheel-picker-item.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { StyleProp, TextStyle, Animated, ViewStyle, Text } from 'react-native';
 import styles from './wheel-picker.style';
 import { isEqual } from 'lodash';
-import { Time } from '../../time-picker';
+import { PickerOption } from 'src/types';
 
 interface ItemProps {
   textStyle: StyleProp<TextStyle>;
   textClassName: string;
   style: StyleProp<ViewStyle>;
-  option: Time | null;
+  option: PickerOption | null;
   height: number;
   index: number;
   currentScrollIndex: Animated.AnimatedAddition<number>;

--- a/src/components/time-picker/wheel-web.tsx
+++ b/src/components/time-picker/wheel-web.tsx
@@ -9,19 +9,18 @@ import {
 } from 'react-native';
 import { sin } from './animated-math';
 import { CONTAINER_HEIGHT } from '../../enums';
-import { ClassNames, Styles } from '../../types';
-import { Time } from '../time-picker';
+import { ClassNames, Styles, PickerOption } from '../../types';
 import { isEqual } from 'lodash';
 
 interface WheelProps {
-  value: number;
-  setValue?: (value: number) => void;
-  items: Time[];
+  value: number | string;
+  setValue?: (value: any) => void;
+  items: PickerOption[];
   styles?: Styles;
   classNames?: ClassNames;
 }
 
-const ITEM_HEIGHT = 40;
+const ITEM_HEIGHT = 44;
 
 const WheelWeb = ({
   value,
@@ -71,8 +70,10 @@ const WheelWeb = ({
         if (newValue?.value === value) {
           translateY.setOffset(0);
           translateY.setValue(0);
-        } else {
-          setValue(newValue?.value || 0);
+        } else if (newValue?.value) {
+          setValue(newValue.value);
+        } else if (items[0]?.value) {
+          setValue(items[0].value);
         }
       },
     });

--- a/src/components/time-picker/wheel-web.tsx
+++ b/src/components/time-picker/wheel-web.tsx
@@ -11,6 +11,7 @@ import { sin } from './animated-math';
 import { CONTAINER_HEIGHT } from '../../enums';
 import { ClassNames, Styles } from '../../types';
 import { Time } from '../time-picker';
+import { isEqual } from 'lodash';
 
 interface WheelProps {
   value: number;
@@ -37,10 +38,9 @@ const WheelWeb = ({
   const height = 140;
   const radius = height / 2;
 
-  const valueIndex = useMemo(
-    () => items.findIndex((item) => item.value === value),
-    [items, value]
-  );
+  const valueIndex = useMemo(() => {
+    return items.findIndex((item) => item.value === value) || 0;
+  }, [items, value]);
 
   const panResponder = useMemo(() => {
     return PanResponder.create({
@@ -92,11 +92,11 @@ const WheelWeb = ({
 
     return Array.from({ length: renderCount }, (_, index) => {
       let targetIndex = valueIndex + index - centerIndex;
-      if (targetIndex < 0 || targetIndex >= items.length) {
-        if (!circular) {
-          return items[0];
-        }
-        targetIndex = (targetIndex + items.length) % items.length;
+      if (circular) {
+        targetIndex =
+          ((targetIndex % items.length) + items.length) % items.length;
+      } else {
+        targetIndex = Math.max(0, Math.min(targetIndex, items.length - 1));
       }
       return items[targetIndex] || items[0];
     });
@@ -199,8 +199,22 @@ const defaultStyles = StyleSheet.create({
   selectedIndicator: {
     position: 'absolute',
     width: '100%',
-    top: '51%',
+    top: '50%',
   },
 });
 
-export default memo(WheelWeb);
+const customComparator = (
+  prev: Readonly<WheelProps>,
+  next: Readonly<WheelProps>
+) => {
+  const areEqual =
+    prev.value === next.value &&
+    prev.setValue === next.setValue &&
+    isEqual(prev.styles, next.styles) &&
+    isEqual(prev.classNames, next.classNames) &&
+    isEqual(prev.items, next.items);
+
+  return areEqual;
+};
+
+export default memo(WheelWeb, customComparator);

--- a/src/components/time-picker/wheel.tsx
+++ b/src/components/time-picker/wheel.tsx
@@ -2,13 +2,12 @@ import React, { memo } from 'react';
 import { Platform } from 'react-native';
 import WheelNative from './wheel-native';
 import WheelWeb from './wheel-web';
-import { ClassNames, Styles } from '../../types';
-import { Time } from '../time-picker';
+import { ClassNames, PickerOption, Styles } from '../../types';
 
 type WheelProps = {
-  value: number;
-  setValue?: (value: number) => void;
-  items: Time[];
+  value: number | string;
+  setValue?: (value: any) => void;
+  items: PickerOption[];
   styles?: Styles;
   classNames?: ClassNames;
 };

--- a/src/datetime-picker.tsx
+++ b/src/datetime-picker.tsx
@@ -109,6 +109,7 @@ const DateTimePicker = (
     year,
     onMonthChange = () => {},
     onYearChange = () => {},
+    use12Hours,
   } = props;
 
   dayjs.tz.setDefault(timeZone);
@@ -603,6 +604,7 @@ const DateTimePicker = (
       disableYearPicker,
       style,
       className,
+      use12Hours,
     }),
     [
       mode,
@@ -630,6 +632,7 @@ const DateTimePicker = (
       disableYearPicker,
       style,
       className,
+      use12Hours,
     ]
   );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,6 +170,7 @@ export interface DatePickerBaseProps {
   year?: number;
   onMonthChange?: (month: number) => void;
   onYearChange?: (year: number) => void;
+  use12Hours?: boolean;
 }
 
 export type Numerals =
@@ -185,3 +186,8 @@ export type Numerals =
   | 'telu'
   | 'knda'
   | 'mlym';
+
+export type PickerOption = {
+  value: number | string;
+  text: string;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,6 +148,7 @@ export interface DatePickerBaseProps {
   firstDayOfWeek?: number;
   showOutsideDays?: boolean;
   timePicker?: boolean;
+  use12Hours?: boolean;
   initialView?: CalendarViews;
   containerHeight?: number;
   weekdaysHeight?: number;
@@ -170,7 +171,6 @@ export interface DatePickerBaseProps {
   year?: number;
   onMonthChange?: (month: number) => void;
   onYearChange?: (year: number) => void;
-  use12Hours?: boolean;
 }
 
 export type Numerals =

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -379,7 +379,9 @@ export const getParsedDate = (date: DateType) => {
     year: dayjs(date).year(),
     month: dayjs(date).month(),
     hour: dayjs(date).hour(),
+    hour12: parseInt(dayjs(date).format('hh')),
     minute: dayjs(date).minute(),
+    period: dayjs(date).format('A'),
   };
 };
 


### PR DESCRIPTION
## Description

This PR adds `use12Hours` prop to the component to use a 12-hour format (AM/PM) in the time picker.

## Related Issues

Closes #120 #101 
