### PR TITLE
Fix: Extend dayjs calendar plugin

### DIFF
--- a/src/datetime-picker.tsx
+++ b/src/datetime-picker.tsx
@@ -41,6 +41,9 @@ import duration from 'dayjs/plugin/duration';
 import { usePrevious } from './hooks/use-previous';
 import jalaliday from 'jalali-plugin-dayjs';
 
+import calendar from 'dayjs/plugin/calendar';
+dayjs.extend(calendar);
+
 dayjs.extend(localeData);
 dayjs.extend(relativeTime);
 dayjs.extend(localizedFormat);


### PR DESCRIPTION
This PR adds the missing extension for the calendar plugin in dayjs inside the datetime-picker.tsx file. Without this, calling dayjs(currentDate).calendar(calendar) results in a runtime TypeError: calendar is not a function.

Extending the plugin fixes the crash, especially after Expo Prebuild or in native Dev Client setups where dayjs plugins must be manually extended.

Thank you for your awesome work on this package! 🙌