### PR TITLE
Fix: trigger month change when pressing the arrows in the calendar

### DIFF
--- a/src/datetime-picker.tsx
+++ b/src/datetime-picker.tsx
@@ -561,12 +561,13 @@ const DateTimePicker = (
   const onChangeMonth = useCallback(
     (value: number) => {
       const newDate = dayjs(stateRef.current.currentDate).add(value, 'month');
+      onSelectMonth(newDate.month());
       dispatch({
         type: CalendarActionKind.CHANGE_CURRENT_DATE,
         payload: dayjs(newDate),
       });
     },
-    [stateRef, dispatch]
+    [stateRef, dispatch, onSelectMonth]
   );
 
   const onChangeYear = useCallback(

--- a/src/datetime-picker.tsx
+++ b/src/datetime-picker.tsx
@@ -560,14 +560,24 @@ const DateTimePicker = (
 
   const onChangeMonth = useCallback(
     (value: number) => {
-      const newDate = dayjs(stateRef.current.currentDate).add(value, 'month');
+      const oldDate = dayjs(stateRef.current.currentDate);
+      const newDate = oldDate.add(value, 'month');
+
       onSelectMonth(newDate.month());
+
+      if (
+        (oldDate.month() === 0 && newDate.month() === 11) ||
+        (oldDate.month() === 11 && newDate.month() === 0)
+      ) {
+        onSelectYear(newDate.year());
+      }
+
       dispatch({
         type: CalendarActionKind.CHANGE_CURRENT_DATE,
         payload: dayjs(newDate),
       });
     },
-    [stateRef, dispatch, onSelectMonth]
+    [stateRef, dispatch, onSelectMonth, onSelectYear]
   );
 
   const onChangeYear = useCallback(


### PR DESCRIPTION
Issue #195 
Trigger `onMonthChange` callback when user change month from the arrows in the calendar display