### PR TITLE
update: export DateTimePicker props type

### DIFF
--- a/src/datetime-picker.tsx
+++ b/src/datetime-picker.tsx
@@ -68,8 +68,10 @@ export interface DatePickerMultipleProps extends DatePickerBaseProps {
   onChange?: MultiChange;
 }
 
+export type DateTimePickerProps = DatePickerSingleProps | DatePickerRangeProps | DatePickerMultipleProps
+
 const DateTimePicker = (
-  props: DatePickerSingleProps | DatePickerRangeProps | DatePickerMultipleProps
+  props: DateTimePickerProps
 ) => {
   const {
     mode = 'single',

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,9 @@ export type {
   CalendarYear,
   CalendarComponents,
 } from './types';
+
 export { useDefaultClassNames, useDefaultStyles } from './theme';
+
+import { DateTimePickerProps } from './datetime-picker';
 
 export default DateTimePicker;


### PR DESCRIPTION
DateTimePicker does not export the props type, so I added it here 👍🏼 