### PR TITLE
fix: first time date picker on UTC mode

### DIFF
--- a/src/datetime-picker.tsx
+++ b/src/datetime-picker.tsx
@@ -1,3 +1,11 @@
+import dayjs from 'dayjs';
+import duration from 'dayjs/plugin/duration';
+import localeData from 'dayjs/plugin/localeData';
+import localizedFormat from 'dayjs/plugin/localizedFormat';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
+import jalaliday from 'jalali-plugin-dayjs';
 import React, {
   useCallback,
   useEffect,
@@ -6,40 +14,32 @@ import React, {
   useRef,
 } from 'react';
 import { I18nManager } from 'react-native';
-import {
-  dateToUnix,
-  getEndOfDay,
-  getStartOfDay,
-  areDatesOnSameDay,
-  removeTime,
-} from './utils';
 import { CalendarContext } from './calendar-context';
+import Calendar from './components/calendar';
 import {
-  CalendarViews,
   CalendarActionKind,
+  CalendarViews,
   CONTAINER_HEIGHT,
   WEEKDAYS_HEIGHT,
 } from './enums';
-import type {
-  DateType,
-  CalendarAction,
-  LocalState,
-  DatePickerBaseProps,
-  SingleChange,
-  RangeChange,
-  MultiChange,
-} from './types';
-import Calendar from './components/calendar';
-import { useDeepCompareMemo } from './utils';
-import dayjs from 'dayjs';
-import localeData from 'dayjs/plugin/localeData';
-import relativeTime from 'dayjs/plugin/relativeTime';
-import localizedFormat from 'dayjs/plugin/localizedFormat';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
-import duration from 'dayjs/plugin/duration';
 import { usePrevious } from './hooks/use-previous';
-import jalaliday from 'jalali-plugin-dayjs';
+import type {
+  CalendarAction,
+  DatePickerBaseProps,
+  DateType,
+  LocalState,
+  MultiChange,
+  RangeChange,
+  SingleChange,
+} from './types';
+import {
+  areDatesOnSameDay,
+  dateToUnix,
+  getEndOfDay,
+  getStartOfDay,
+  removeTime,
+  useDeepCompareMemo,
+} from './utils';
 
 dayjs.extend(localeData);
 dayjs.extend(relativeTime);
@@ -294,11 +294,13 @@ const DateTimePicker = (
 
   useEffect(() => {
     if (mode === 'single') {
-      let _date =
+       let _date =
         (date &&
-          (timePicker
-            ? dayjs.tz(date, timeZone)
-            : getStartOfDay(dayjs.tz(date, timeZone)))) ??
+          (timeZone === 'UTC'
+            ? dayjs(date)
+            : timePicker
+              ? dayjs.tz(date, timeZone)
+              : getStartOfDay(dayjs.tz(date, timeZone)))) ??
         date;
 
       if (_date && maxDate && dayjs.tz(_date, timeZone).isAfter(maxDate)) {


### PR DESCRIPTION
This pull request refactors the `src/datetime-picker.tsx` file to improve code organization and functionality. The changes include restructuring imports for better readability, adding support for time zones, and ensuring proper handling of date and time operations using the `dayjs` library.

### Code organization and readability:

* Consolidated and reordered imports for better clarity, grouping related imports together [[1]](diffhunk://#diff-7650b97c0c117cdcbb9d6b4c21182a64fc9629f9abf2f1abce124494874fcfa2R1-R8) [[2]](diffhunk://#diff-7650b97c0c117cdcbb9d6b4c21182a64fc9629f9abf2f1abce124494874fcfa2L9-R42).
* Moved utility functions (`areDatesOnSameDay`, `dateToUnix`, etc.) back into the main import block from `./utils` for consistency.

### Time zone and date handling:

* Updated the logic in the `DateTimePicker` component to handle time zones more robustly by using `dayjs.tz` when a time zone is provided, or defaulting to UTC when specified.