### PR TITLE
fix: make time wheel accept 00 via numeric comparison…

### DIFF
--- a/src/__tests__/wheel-web.00.test.tsx
+++ b/src/__tests__/wheel-web.00.test.tsx
@@ -1,0 +1,82 @@
+/**
+ *  - Render the *web* wheel component and simulate a drag that lands on "00".
+ *  - Assert the component calls setValue(0) (a number).
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { PanResponder } from 'react-native';
+import WheelWeb from '../components/time-picker/wheel-web';
+import type { PickerOption } from '../types';
+
+// Helper to build options that reproduce a web bug where 00 wasn't selectable.
+const makeItems = (n = 5): PickerOption[] =>
+  Array.from({ length: n }, (_, i) => ({
+    value: i === 0 ? '00' : i, // "00", 1, 2, 3, ...
+    text: String(i).padStart(2, '0'), // "00", "01", "02", ...
+  }));
+
+describe('WheelWeb — selecting 00', () => {
+  let panSpec: any | null = null;
+
+  beforeEach(() => {
+    panSpec = null;
+    jest.spyOn(PanResponder, 'create').mockImplementation((spec: any) => {
+      panSpec = spec;
+      return { panHandlers: spec } as any;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('emits numeric 0 when landing on "00"', () => {
+    // Build the wheel options the component will render (replicate bug condition):
+    const items = makeItems(5); // ["00", 1, 2, 3, 4]
+    const setValue = jest.fn();
+
+    render(
+      <WheelWeb
+        value={1} // start on "01"
+        items={items}
+        setValue={setValue}
+        styles={{}}
+        classNames={{} as any}
+      />
+    );
+
+    expect(panSpec).toBeTruthy(); // Sanity: confirm we captured the gesture handlers
+
+    const STEP = 28;
+    panSpec.onPanResponderGrant(); // Simulates “finger down” (gesture start).
+    panSpec.onPanResponderRelease({}, { dy: STEP }); // Simulates “finger up” after dragging by 1 row.
+
+    expect(setValue).toHaveBeenCalledTimes(1);
+    expect(setValue).toHaveBeenCalledWith(0);
+  });
+
+  test('no change when releasing on the same value (including "00")', () => {
+    const items = makeItems(5);
+    const setValue = jest.fn();
+
+    // Start already on 0 (which will match "00" thanks to Number(...))
+    render(
+      <WheelWeb
+        value={0}
+        items={items}
+        setValue={setValue}
+        styles={{}}
+        classNames={{} as any}
+      />
+    );
+
+    expect(panSpec).toBeTruthy();
+
+    // Release without moving (dy = 0) → should not emit anything
+    panSpec.onPanResponderGrant();
+    panSpec.onPanResponderRelease({}, { dy: 0 });
+
+    expect(setValue).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/time-picker/wheel-web.tsx
+++ b/src/components/time-picker/wheel-web.tsx
@@ -38,7 +38,10 @@ const WheelWeb = ({
   const radius = height / 2;
 
   const valueIndex = useMemo(() => {
-    return items.findIndex((item) => item.value === value) || 0;
+    const idx = items.findIndex(
+      (item) => Number(item?.value) === Number(value)
+    );
+    return idx >= 0 ? idx : 0;
   }, [items, value]);
 
   const panResponder = useMemo(() => {
@@ -67,13 +70,13 @@ const WheelWeb = ({
           }
         }
         const newValue = items[newValueIndex];
-        if (newValue?.value === value) {
+        if (Number(newValue?.value) === Number(value)) {
           translateY.setOffset(0);
           translateY.setValue(0);
-        } else if (newValue?.value) {
-          setValue(newValue.value);
-        } else if (items[0]?.value) {
-          setValue(items[0].value);
+        } else if (newValue?.value != null) {
+          setValue(Number(newValue.value));
+        } else if (items[0]?.value != null) {
+          setValue(Number(items[0].value));
         }
       },
     });
@@ -107,7 +110,7 @@ const WheelWeb = ({
     //translateY.setValue(0);
     translateY.setOffset(0);
     const currentIndex = displayValues.findIndex(
-      (item) => item?.value === value
+      (item) => Number(item?.value) === Number(value)
     );
     return displayValues && displayValues.length > 0
       ? displayValues.map((_, index) =>
@@ -166,7 +169,7 @@ const WheelWeb = ({
                     },
                   ]
                 : [],
-              opacity: displayValue?.value !== value ? 0.3 : 1,
+              opacity: Number(displayValue?.value) !== Number(value) ? 0.3 : 1,
             }}
           >
             <Text style={styles?.time_label} className={classNames?.time_label}>


### PR DESCRIPTION
**Summary**
The time wheel on web couldn’t select 00 because the wheel compared values with strict equality between mixed types (e.g. "00" vs 0). This PR normalises comparisons to numbers and always emits numeric values, so "00", "0", and 0 are treated the same.

**Problem**

- wheel-web.tsx used item.value === value in several places.
- On web, hour/minute options may be zero-padded strings (e.g. "00"), while the current value is a number (0).
- Strict equality failed, so the wheel couldn’t “land” on 00.

**What changed**

- In src/components/time-picker/wheel-web.tsx:
    - Find current index with Number(item.value) === Number(value).
    - On release, compare numerically and emit Number(newValue.value).
    - Dim/selected state comparisons switched to numeric comparison as well.

**Why this approach**

- Smallest change, scoped to the web wheel only.
- Keeps public API behaviour stable for consumers (downstream logic keeps receiving numbers).
- No impact on iOS/Android implementations.

**Notes**
(Optional) If you’d like, I can follow up with a type-only PR to narrow setValue?: (value: number) => void since we now always emit numbers.

Closes #210 
**Testing**

**Manual Testing**
00:00 time can now be selected via the wheels on the web as shown here:
<img width="719" height="500" alt="image" src="https://github.com/user-attachments/assets/9ddf586b-78aa-4393-addc-248661da97f6" />


**Automated Unit Tests**
Added web wheel tests to ensure ‘00’ is selectable—simulate a one-step drag via a mocked PanResponder and assert it emits numeric 0 (and no-op when unchanged), covering mixed string/number values to guard against regressions.