### PR TITLE
fix: allow month 0 to focus initial month

### DIFF
--- a/src/datetime-picker.tsx
+++ b/src/datetime-picker.tsx
@@ -155,7 +155,7 @@ const DateTimePicker = (
       initialDate = dayjs(minDate);
     }
 
-    if (month !== undefined && month && month >= 0 && month <= 11) {
+    if (typeof month === 'number' && month >= 0 && month <= 11) {
       initialDate = initialDate.month(month);
     }
 


### PR DESCRIPTION
## What
Allow `month=0` to be applied when setting the initial focused month.

## Why
When opening the calendar, the focused month could not be set to January (0) because the check treated 0 as falsy.

## How
Use a numeric check for `month` so 0 is allowed.