### PR TITLE
chore: remove lodash dependency, use native deepEqual

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "@testing-library/jest-native": "^5.4.3",
     "@testing-library/react-native": "^12.3.2",
     "@types/jest": "^29.5.14",
-    "@types/lodash": "^4.14.202",
     "@types/react": "18.2.0",
     "@types/react-native": "0.72.0",
     "@types/react-test-renderer": "^18.0.0",
@@ -169,7 +168,6 @@
     "clsx": "^2.1.1",
     "dayjs": "^1.11.13",
     "jalali-plugin-dayjs": "^1.1.4",
-    "lodash": "^4.17.21",
     "tailwind-merge": "^3.0.1"
   }
 }

--- a/src/__tests__/deepEqual.test.ts
+++ b/src/__tests__/deepEqual.test.ts
@@ -1,0 +1,343 @@
+import dayjs from 'dayjs';
+import { deepEqual } from '../utils';
+
+describe('deepEqual', () => {
+  // ─── Primitives ──────────────────────────────────────────────────────
+  describe('primitives', () => {
+    test('equal strings', () => {
+      expect(deepEqual('hello', 'hello')).toBe(true);
+    });
+
+    test('unequal strings', () => {
+      expect(deepEqual('hello', 'world')).toBe(false);
+    });
+
+    test('empty strings', () => {
+      expect(deepEqual('', '')).toBe(true);
+    });
+
+    test('equal numbers', () => {
+      expect(deepEqual(42, 42)).toBe(true);
+    });
+
+    test('unequal numbers', () => {
+      expect(deepEqual(42, 43)).toBe(false);
+    });
+
+    test('zero and zero', () => {
+      expect(deepEqual(0, 0)).toBe(true);
+    });
+
+    test('equal booleans', () => {
+      expect(deepEqual(true, true)).toBe(true);
+      expect(deepEqual(false, false)).toBe(true);
+    });
+
+    test('unequal booleans', () => {
+      expect(deepEqual(true, false)).toBe(false);
+    });
+
+    test('null and null', () => {
+      expect(deepEqual(null, null)).toBe(true);
+    });
+
+    test('undefined and undefined', () => {
+      expect(deepEqual(undefined, undefined)).toBe(true);
+    });
+
+    test('NaN and NaN', () => {
+      // Object.is(NaN, NaN) is true, so deepEqual should return true
+      expect(deepEqual(NaN, NaN)).toBe(true);
+    });
+
+    test('+0 vs -0', () => {
+      // Object.is(+0, -0) is false — this is intentional behavior
+      expect(deepEqual(+0, -0)).toBe(false);
+    });
+  });
+
+  // ─── Null / Undefined edge cases ────────────────────────────────────
+  describe('null and undefined', () => {
+    test('null vs undefined', () => {
+      expect(deepEqual(null, undefined)).toBe(false);
+    });
+
+    test('null vs object', () => {
+      expect(deepEqual(null, {})).toBe(false);
+    });
+
+    test('undefined vs object', () => {
+      expect(deepEqual(undefined, {})).toBe(false);
+    });
+
+    test('null vs zero', () => {
+      expect(deepEqual(null, 0)).toBe(false);
+    });
+
+    test('undefined vs empty string', () => {
+      expect(deepEqual(undefined, '')).toBe(false);
+    });
+  });
+
+  // ─── Plain objects ───────────────────────────────────────────────────
+  describe('plain objects', () => {
+    test('equal flat objects', () => {
+      expect(deepEqual({ a: 1, b: 2 }, { a: 1, b: 2 })).toBe(true);
+    });
+
+    test('unequal flat objects', () => {
+      expect(deepEqual({ a: 1, b: 2 }, { a: 1, b: 3 })).toBe(false);
+    });
+
+    test('different key counts', () => {
+      expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+    });
+
+    test('empty objects', () => {
+      expect(deepEqual({}, {})).toBe(true);
+    });
+
+    test('nested equal objects', () => {
+      expect(
+        deepEqual({ a: { b: { c: 1 } } }, { a: { b: { c: 1 } } })
+      ).toBe(true);
+    });
+
+    test('nested unequal objects', () => {
+      expect(
+        deepEqual({ a: { b: { c: 1 } } }, { a: { b: { c: 2 } } })
+      ).toBe(false);
+    });
+
+    test('different key order should still be equal', () => {
+      expect(deepEqual({ a: 1, b: 2, c: 3 }, { c: 3, a: 1, b: 2 })).toBe(
+        true
+      );
+    });
+
+    test('{a: undefined} vs {} should NOT be equal', () => {
+      // These have different key sets: one has key "a", the other does not
+      expect(deepEqual({ a: undefined }, {})).toBe(false);
+    });
+
+    test('object with key present vs missing key', () => {
+      expect(deepEqual({ a: 1, b: undefined }, { a: 1 })).toBe(false);
+    });
+  });
+
+  // ─── Arrays ──────────────────────────────────────────────────────────
+  describe('arrays', () => {
+    test('equal flat arrays', () => {
+      expect(deepEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+    });
+
+    test('unequal flat arrays', () => {
+      expect(deepEqual([1, 2, 3], [1, 2, 4])).toBe(false);
+    });
+
+    test('different length arrays', () => {
+      expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
+    });
+
+    test('empty arrays', () => {
+      expect(deepEqual([], [])).toBe(true);
+    });
+
+    test('nested equal arrays', () => {
+      expect(deepEqual([[1, 2], [3, 4]], [[1, 2], [3, 4]])).toBe(true);
+    });
+
+    test('nested unequal arrays', () => {
+      expect(deepEqual([[1, 2], [3, 4]], [[1, 2], [3, 5]])).toBe(false);
+    });
+
+    test('arrays with objects', () => {
+      expect(deepEqual([{ a: 1 }], [{ a: 1 }])).toBe(true);
+      expect(deepEqual([{ a: 1 }], [{ a: 2 }])).toBe(false);
+    });
+  });
+
+  // ─── Array vs Object ────────────────────────────────────────────────
+  describe('array vs object', () => {
+    test('array vs plain object', () => {
+      expect(deepEqual([1, 2], { 0: 1, 1: 2 })).toBe(false);
+    });
+
+    test('empty array vs empty object', () => {
+      expect(deepEqual([], {})).toBe(false);
+    });
+  });
+
+  // ─── Date objects ────────────────────────────────────────────────────
+  describe('Date objects', () => {
+    test('equal dates', () => {
+      const d1 = new Date(2024, 0, 1);
+      const d2 = new Date(2024, 0, 1);
+      expect(deepEqual(d1, d2)).toBe(true);
+    });
+
+    test('different dates', () => {
+      const d1 = new Date(2024, 0, 1);
+      const d2 = new Date(2024, 5, 15);
+      expect(deepEqual(d1, d2)).toBe(false);
+    });
+
+    test('same timestamp dates', () => {
+      const ts = 1704067200000;
+      expect(deepEqual(new Date(ts), new Date(ts))).toBe(true);
+    });
+  });
+
+  // ─── dayjs objects ───────────────────────────────────────────────────
+  describe('dayjs objects', () => {
+    test('equal dayjs dates', () => {
+      const a = dayjs('2024-01-15');
+      const b = dayjs('2024-01-15');
+      // dayjs objects are plain objects internally; deepEqual compares by keys
+      expect(deepEqual(a, b)).toBe(true);
+    });
+
+    test('different dayjs dates', () => {
+      const a = dayjs('2024-01-15');
+      const b = dayjs('2024-06-20');
+      expect(deepEqual(a, b)).toBe(false);
+    });
+  });
+
+  // ─── Functions ───────────────────────────────────────────────────────
+  describe('functions', () => {
+    test('same function reference is equal', () => {
+      const fn = () => {};
+      expect(deepEqual(fn, fn)).toBe(true);
+    });
+
+    test('different function references are not equal', () => {
+      const fn1 = () => {};
+      const fn2 = () => {};
+      expect(deepEqual(fn1, fn2)).toBe(false);
+    });
+  });
+
+  // ─── Mixed / cross-type comparisons ─────────────────────────────────
+  describe('mixed types', () => {
+    test('number vs string', () => {
+      expect(deepEqual(1, '1')).toBe(false);
+    });
+
+    test('boolean vs number', () => {
+      expect(deepEqual(true, 1)).toBe(false);
+    });
+
+    test('string vs object', () => {
+      expect(deepEqual('hello', { value: 'hello' })).toBe(false);
+    });
+
+    test('number vs null', () => {
+      expect(deepEqual(0, null)).toBe(false);
+    });
+
+    test('array vs string', () => {
+      expect(deepEqual([1], '1')).toBe(false);
+    });
+  });
+
+  // ─── Deeply nested structures ────────────────────────────────────────
+  describe('deeply nested structures', () => {
+    test('deeply nested equal objects', () => {
+      const obj = {
+        level1: {
+          level2: {
+            level3: {
+              level4: {
+                value: 'deep',
+                arr: [1, { nested: true }],
+              },
+            },
+          },
+        },
+      };
+
+      const clone = {
+        level1: {
+          level2: {
+            level3: {
+              level4: {
+                value: 'deep',
+                arr: [1, { nested: true }],
+              },
+            },
+          },
+        },
+      };
+
+      expect(deepEqual(obj, clone)).toBe(true);
+    });
+
+    test('deeply nested unequal objects', () => {
+      const a = {
+        level1: { level2: { level3: { value: 'a' } } },
+      };
+      const b = {
+        level1: { level2: { level3: { value: 'b' } } },
+      };
+      expect(deepEqual(a, b)).toBe(false);
+    });
+
+    test('complex mixed structure', () => {
+      const structure = {
+        users: [
+          { name: 'Alice', scores: [100, 95, 88] },
+          { name: 'Bob', scores: [90, 85, 92] },
+        ],
+        metadata: {
+          count: 2,
+          active: true,
+        },
+      };
+
+      const identical = {
+        users: [
+          { name: 'Alice', scores: [100, 95, 88] },
+          { name: 'Bob', scores: [90, 85, 92] },
+        ],
+        metadata: {
+          count: 2,
+          active: true,
+        },
+      };
+
+      expect(deepEqual(structure, identical)).toBe(true);
+    });
+
+    test('complex mixed structure with one difference', () => {
+      const a = {
+        users: [
+          { name: 'Alice', scores: [100, 95, 88] },
+          { name: 'Bob', scores: [90, 85, 92] },
+        ],
+      };
+
+      const b = {
+        users: [
+          { name: 'Alice', scores: [100, 95, 88] },
+          { name: 'Bob', scores: [90, 85, 93] }, // last score differs
+        ],
+      };
+
+      expect(deepEqual(a, b)).toBe(false);
+    });
+  });
+
+  // ─── Same reference identity ─────────────────────────────────────────
+  describe('reference identity', () => {
+    test('same object reference', () => {
+      const obj = { a: 1 };
+      expect(deepEqual(obj, obj)).toBe(true);
+    });
+
+    test('same array reference', () => {
+      const arr = [1, 2, 3];
+      expect(deepEqual(arr, arr)).toBe(true);
+    });
+  });
+});

--- a/src/components/day.tsx
+++ b/src/components/day.tsx
@@ -8,8 +8,7 @@ import {
   DateType,
 } from '../types';
 import { CONTAINER_HEIGHT, WEEKDAYS_HEIGHT } from '../enums';
-import { cn } from '../utils';
-import { isEqual } from 'lodash';
+import { cn, deepEqual } from '../utils';
 
 interface Props {
   day: CalendarDay;
@@ -223,12 +222,12 @@ const createDefaultStyles = (containerHeight: number, weekdaysHeight: number) =>
 
 const customComparator = (prev: Readonly<Props>, next: Readonly<Props>) => {
   const areEqual =
-    isEqual(prev.day, next.day) &&
+    deepEqual(prev.day, next.day) &&
     prev.onSelectDate === next.onSelectDate &&
     prev.containerHeight === next.containerHeight &&
-    isEqual(prev.styles, next.styles) &&
-    isEqual(prev.classNames, next.classNames) &&
-    isEqual(prev.components, next.components);
+    deepEqual(prev.styles, next.styles) &&
+    deepEqual(prev.classNames, next.classNames) &&
+    deepEqual(prev.components, next.components);
 
   return areEqual;
 };

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -4,7 +4,7 @@ import type { HeaderProps, NavigationProps } from './types';
 import PrevButton from './prev-button';
 import NextButton from './next-button';
 import Selectors from './selectors';
-import { isEqual } from 'lodash';
+import { deepEqual } from '../../utils';
 
 const createDefaultStyles = (isRTL: boolean) =>
   StyleSheet.create({
@@ -107,8 +107,8 @@ const customComparator = (
     prev.NextIcon === next.NextIcon &&
     prev.navigationPosition === next.navigationPosition &&
     prev.isRTL === next.isRTL &&
-    isEqual(prev.styles, next.styles) &&
-    isEqual(prev.classNames, next.classNames);
+    deepEqual(prev.styles, next.styles) &&
+    deepEqual(prev.classNames, next.classNames);
 
   return areEqual;
 };

--- a/src/components/header/next-button.tsx
+++ b/src/components/header/next-button.tsx
@@ -11,7 +11,7 @@ import { useCalendarContext } from '../../calendar-context';
 import { YEAR_PAGE_SIZE } from '../../utils';
 import { ClassNames, Styles } from '../../types';
 import { UI } from '../../ui';
-import { isEqual } from 'lodash';
+import { deepEqual } from '../../utils';
 import { COLORS } from '../../theme';
 
 const arrow_right = require('../../assets/images/arrow_right.png');
@@ -94,9 +94,9 @@ const customComparator = (
 ) => {
   const areEqual =
     prev.className === next.className &&
-    isEqual(prev.style, next.style) &&
-    isEqual(prev.imageStyle, next.imageStyle) &&
-    isEqual(prev.imageClassName, next.imageClassName);
+    deepEqual(prev.style, next.style) &&
+    deepEqual(prev.imageStyle, next.imageStyle) &&
+    deepEqual(prev.imageClassName, next.imageClassName);
 
   return areEqual;
 };

--- a/src/components/header/prev-button.tsx
+++ b/src/components/header/prev-button.tsx
@@ -11,7 +11,7 @@ import { useCalendarContext } from '../../calendar-context';
 import { YEAR_PAGE_SIZE } from '../../utils';
 import { ClassNames, Styles } from '../../types';
 import { UI } from '../../ui';
-import { isEqual } from 'lodash';
+import { deepEqual } from '../../utils';
 import { COLORS } from '../../theme';
 
 const arrow_left = require('../../assets/images/arrow_left.png');
@@ -94,9 +94,9 @@ const customComparator = (
 ) => {
   const areEqual =
     prev.className === next.className &&
-    isEqual(prev.style, next.style) &&
-    isEqual(prev.imageStyle, next.imageStyle) &&
-    isEqual(prev.imageClassName, next.imageClassName);
+    deepEqual(prev.style, next.style) &&
+    deepEqual(prev.imageStyle, next.imageStyle) &&
+    deepEqual(prev.imageClassName, next.imageClassName);
 
   return areEqual;
 };

--- a/src/components/time-picker/period-native.tsx
+++ b/src/components/time-picker/period-native.tsx
@@ -1,7 +1,7 @@
 import React, { memo } from 'react';
 import WheelPicker from './wheel-picker';
 import { ClassNames, PickerOption, Styles } from '../../types';
-import { isEqual } from 'lodash';
+import { deepEqual } from '../../utils';
 
 interface PeriodProps {
   value: string;
@@ -44,8 +44,8 @@ const customComparator = (
   const areEqual =
     prev.value === next.value &&
     prev.setValue === next.setValue &&
-    isEqual(prev.styles, next.styles) &&
-    isEqual(prev.classNames, next.classNames);
+    deepEqual(prev.styles, next.styles) &&
+    deepEqual(prev.classNames, next.classNames);
 
   return areEqual;
 };

--- a/src/components/time-picker/period-web.tsx
+++ b/src/components/time-picker/period-web.tsx
@@ -1,7 +1,7 @@
 import React, { memo } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { ClassNames, Styles } from '../../types';
-import { isEqual } from 'lodash';
+import { deepEqual } from '../../utils';
 
 interface PeriodProps {
   value: string;
@@ -46,8 +46,8 @@ const customComparator = (
   const areEqual =
     prev.value === next.value &&
     prev.setValue === next.setValue &&
-    isEqual(prev.styles, next.styles) &&
-    isEqual(prev.classNames, next.classNames);
+    deepEqual(prev.styles, next.styles) &&
+    deepEqual(prev.classNames, next.classNames);
 
   return areEqual;
 };

--- a/src/components/time-picker/wheel-picker/wheel-picker-item.tsx
+++ b/src/components/time-picker/wheel-picker/wheel-picker-item.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleProp, TextStyle, Animated, ViewStyle, Text } from 'react-native';
 import styles from './wheel-picker.style';
-import { isEqual } from 'lodash';
+import { deepEqual } from '../../../utils';
 import { PickerOption } from 'src/types';
 
 interface ItemProps {
@@ -142,7 +142,7 @@ const customComparator = (
 ) => {
   return (
     prevProps.textClassName === nextProps.textClassName &&
-    isEqual(prevProps.textStyle, nextProps.textStyle)
+    deepEqual(prevProps.textStyle, nextProps.textStyle)
   );
 };
 

--- a/src/components/time-picker/wheel-web.tsx
+++ b/src/components/time-picker/wheel-web.tsx
@@ -10,7 +10,7 @@ import {
 import { sin } from './animated-math';
 import { CONTAINER_HEIGHT } from '../../enums';
 import { ClassNames, Styles, PickerOption } from '../../types';
-import { isEqual } from 'lodash';
+import { deepEqual } from '../../utils';
 
 interface WheelProps {
   value: number | string;
@@ -211,9 +211,9 @@ const customComparator = (
   const areEqual =
     prev.value === next.value &&
     prev.setValue === next.setValue &&
-    isEqual(prev.styles, next.styles) &&
-    isEqual(prev.classNames, next.classNames) &&
-    isEqual(prev.items, next.items);
+    deepEqual(prev.styles, next.styles) &&
+    deepEqual(prev.classNames, next.classNames) &&
+    deepEqual(prev.items, next.items);
 
   return areEqual;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,7 +10,6 @@ import type {
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import { useRef } from 'react';
-import { isEqual } from 'lodash';
 import { numeralSystems } from './numerals';
 
 export const CALENDAR_FORMAT = 'YYYY-MM-DD HH:mm';
@@ -577,6 +576,43 @@ const generateCalendarDay = (
   };
 };
 
+/**
+ * Deep equality comparison for plain objects, arrays, dates, and primitives.
+ * Used as a lightweight replacement for lodash.isEqual in React.memo comparators.
+ */
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (a == null || b == null) return false;
+  if (typeof a !== typeof b) return false;
+
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime();
+  }
+
+  if (typeof a !== 'object') return false;
+
+  const arrA = Array.isArray(a);
+  const arrB = Array.isArray(b);
+  if (arrA !== arrB) return false;
+
+  if (arrA && arrB) {
+    if (a.length !== (b as unknown[]).length) return false;
+    return a.every((val, i) => deepEqual(val, (b as unknown[])[i]));
+  }
+
+  const objA = a as Record<string, unknown>;
+  const objB = b as Record<string, unknown>;
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+  if (keysA.length !== keysB.length) return false;
+
+  return keysA.every(
+    (key) =>
+      Object.prototype.hasOwnProperty.call(objB, key) &&
+      deepEqual(objA[key], objB[key])
+  );
+}
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
@@ -595,7 +631,7 @@ export function useDeepCompareMemo<T>(value: T, deps: any[]): T {
 
   if (
     !depsRef.current ||
-    !deps.every((dep, i) => isEqual(dep, depsRef.current![i]))
+    !deps.every((dep, i) => deepEqual(dep, depsRef.current![i]))
   ) {
     ref.current = value;
     depsRef.current = deps;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2225,11 +2225,6 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/lodash@^4.14.202":
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.15.tgz#12d4af0ed17cc7600ce1f9980cec48fc17ad1e89"
-  integrity sha512-w/P33JFeySuhN6JLkysYUK2gEmy9kHHFN7E8ro0tkfmlDOgxBDzWEZ/J8cWA+fHqFevpswDTFZnDx+R9lbL6xw==
-
 "@types/minimist@^1.2.0", "@types/minimist@^1.2.2":
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.5.tgz#ec10755e871497bcd83efe927e43ec46e8c0747e"


### PR DESCRIPTION
## Summary
- Replace `lodash.isEqual` with a lightweight inline `deepEqual` utility
- Remove `lodash` and `@types/lodash` from dependencies
- Reduces bundle size by removing ~530KB lodash dependency

## Changes
- `src/utils.ts` — add `deepEqual()` function, remove lodash import
- `src/components/day.tsx` — use `deepEqual` from utils
- `src/components/header/index.tsx` — use `deepEqual` from utils
- `src/components/header/next-button.tsx` — use `deepEqual` from utils
- `src/components/header/prev-button.tsx` — use `deepEqual` from utils
- `src/components/time-picker/period-native.tsx` — use `deepEqual` from utils
- `src/components/time-picker/period-web.tsx` — use `deepEqual` from utils
- `src/components/time-picker/wheel-web.tsx` — use `deepEqual` from utils
- `src/components/time-picker/wheel-picker/wheel-picker-item.tsx` — use `deepEqual` from utils
- `package.json` — remove `lodash` and `@types/lodash`
- `yarn.lock` — regenerated

## Testing
- `yarn test` — 2 suites, 2 tests passed
- `npx tsc --noEmit` — zero type errors
- `yarn lint` — zero errors (only pre-existing warnings)
- Pre-commit hooks (lefthook: types + commitlint) passed

Addresses #237