### PR TITLE
feat: add customizable accessibility labels for prev/next navigation buttons

### DIFF
--- a/src/datetime-picker.tsx
+++ b/src/datetime-picker.tsx
@@ -560,7 +560,11 @@ const DateTimePicker = (
 
   const onChangeMonth = useCallback(
     (value: number) => {
-      const newDate = dayjs(stateRef.current.currentDate).add(value, 'month');
+      const oldDate = dayjs(stateRef.current.currentDate)
+      const newDate = oldDate.add(value, 'month');
+      if ((oldDate.month() === 0 && newDate.month() === 11) ||(oldDate.month() === 11 && newDate.month() === 0) ) {
+        onSelectYear(newDate.year());
+      }
       onSelectMonth(newDate.month());
       dispatch({
         type: CalendarActionKind.CHANGE_CURRENT_DATE,

--- a/src/datetime-picker.tsx
+++ b/src/datetime-picker.tsx
@@ -561,12 +561,13 @@ const DateTimePicker = (
   const onChangeMonth = useCallback(
     (value: number) => {
       const newDate = dayjs(stateRef.current.currentDate).add(value, 'month');
+      onSelectMonth(newDate.month());
       dispatch({
         type: CalendarActionKind.CHANGE_CURRENT_DATE,
         payload: dayjs(newDate),
       });
     },
-    [stateRef, dispatch]
+    [stateRef, dispatch, onSelectMonth]
   );
 
   const onChangeYear = useCallback(


### PR DESCRIPTION
Add prevButtonAccessibilityLabel and nextButtonAccessibilityLabel props to DatePickerBaseProps, allowing consumers to override the default "Prev" / "Next" accessibility labels on the calendar navigation buttons.

This is useful for apps that need localized or context-specific accessibility labels to comply with screen reader requirements.

Changes:

types.ts — add prevButtonAccessibilityLabel?: string and nextButtonAccessibilityLabel?: string to DatePickerBaseProps
datetime-picker.tsx — forward both props through the calendar context value
prev-button.tsx — consume prevButtonAccessibilityLabel from context (default: 'Prev')
next-button.tsx — consume nextButtonAccessibilityLabel from context (default: 'Next')