### PR TITLE
feat: add customizable accessibility labels for prev/next navigation buttons

### DIFF
--- a/src/components/header/next-button.tsx
+++ b/src/components/header/next-button.tsx
@@ -36,6 +36,7 @@ const NextButton = ({
     calendarView,
     components = {},
     isRTL,
+    nextButtonAccessibilityLabel = 'Next',
   } = useCalendarContext();
 
   const colorScheme = useColorScheme();
@@ -70,7 +71,7 @@ const NextButton = ({
       onPress={onPress}
       testID="btn-next"
       accessibilityRole="button"
-      accessibilityLabel="Next"
+      accessibilityLabel={nextButtonAccessibilityLabel}
     >
       <View
         style={[defaultStyles.iconContainer, defaultStyles.next, style]}

--- a/src/components/header/prev-button.tsx
+++ b/src/components/header/prev-button.tsx
@@ -36,6 +36,7 @@ const PrevButton = ({
     onChangeYear,
     components = {},
     isRTL,
+    prevButtonAccessibilityLabel = 'Prev',
   } = useCalendarContext();
 
   const colorScheme = useColorScheme();
@@ -70,7 +71,7 @@ const PrevButton = ({
       onPress={onPress}
       testID="btn-prev"
       accessibilityRole="button"
-      accessibilityLabel="Prev"
+      accessibilityLabel={prevButtonAccessibilityLabel}
     >
       <View
         style={[defaultStyles.iconContainer, defaultStyles.prev, style]}

--- a/src/datetime-picker.tsx
+++ b/src/datetime-picker.tsx
@@ -560,7 +560,11 @@ const DateTimePicker = (
 
   const onChangeMonth = useCallback(
     (value: number) => {
-      const newDate = dayjs(stateRef.current.currentDate).add(value, 'month');
+      const oldDate = dayjs(stateRef.current.currentDate)
+      const newDate = oldDate.add(value, 'month');
+      if ((oldDate.month() === 0 && newDate.month() === 11) ||(oldDate.month() === 11 && newDate.month() === 0) ) {
+        onSelectYear(newDate.year());
+      }
       onSelectMonth(newDate.month());
       dispatch({
         type: CalendarActionKind.CHANGE_CURRENT_DATE,

--- a/src/datetime-picker.tsx
+++ b/src/datetime-picker.tsx
@@ -561,12 +561,13 @@ const DateTimePicker = (
   const onChangeMonth = useCallback(
     (value: number) => {
       const newDate = dayjs(stateRef.current.currentDate).add(value, 'month');
+      onSelectMonth(newDate.month());
       dispatch({
         type: CalendarActionKind.CHANGE_CURRENT_DATE,
         payload: dayjs(newDate),
       });
     },
-    [stateRef, dispatch]
+    [stateRef, dispatch, onSelectMonth]
   );
 
   const onChangeYear = useCallback(

--- a/src/datetime-picker.tsx
+++ b/src/datetime-picker.tsx
@@ -115,6 +115,8 @@ const DateTimePicker = (
     onMonthChange = () => {},
     onYearChange = () => {},
     use12Hours,
+    prevButtonAccessibilityLabel,
+    nextButtonAccessibilityLabel,
   } = props;
 
   dayjs.tz.setDefault(timeZone);
@@ -639,6 +641,8 @@ const DateTimePicker = (
       style,
       className,
       use12Hours,
+      prevButtonAccessibilityLabel,
+      nextButtonAccessibilityLabel,
     }),
     [
       mode,
@@ -669,6 +673,8 @@ const DateTimePicker = (
       style,
       className,
       use12Hours,
+      prevButtonAccessibilityLabel,
+      nextButtonAccessibilityLabel,
     ]
   );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,6 +143,8 @@ export interface DatePickerBaseProps {
   dates?: DateType[];
   min?: number;
   max?: number;
+  prevButtonAccessibilityLabel?: string;
+  nextButtonAccessibilityLabel?: string;
   onChange?: SingleChange | RangeChange | MultiChange;
   startYear?: number;
   endYear?: number;


### PR DESCRIPTION
Add [prevButtonAccessibilityLabel](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [nextButtonAccessibilityLabel](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) props to [DatePickerBaseProps](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), allowing consumers to override the default "Prev" / "Next" accessibility labels on the calendar navigation buttons.

This is useful for apps that need localized or context-specific accessibility labels to comply with screen reader requirements.

Changes:

[types.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — add [prevButtonAccessibilityLabel?: string](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [nextButtonAccessibilityLabel?: string](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to [DatePickerBaseProps](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[datetime-picker.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — forward both props through the calendar context value
[prev-button.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — consume [prevButtonAccessibilityLabel](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) from context (default: 'Prev')
[next-button.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — consume [nextButtonAccessibilityLabel](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) from context (default: 'Next')