### PR TITLE
Expose DatepickerProps

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export type {
   CalendarMonth,
   CalendarYear,
   CalendarComponents,
+  DatePickerBaseProps
 } from './types';
 export { useDefaultClassNames, useDefaultStyles } from './theme';
 


### PR DESCRIPTION
Datepicker props is used for maintaining the component in projects so this would be useful.