### PR TITLE
Range calendar jalali onchange undefined problem

### DIFF
--- a/src/components/days.tsx
+++ b/src/components/days.tsx
@@ -117,8 +117,10 @@ const Days = () => {
         if (
           (isFirstDayOfMonth && selectedEndDay) ||
           (isLastDayOfMonth && selectedStartDay) ||
-          dayjs(startDate).format('DDMMYYYY') ===
-            dayjs(endDate).format('DDMMYYYY')
+          (startDate &&
+            endDate &&
+            dayjs(startDate).format('DDMMYYYY') ===
+              dayjs(endDate).format('DDMMYYYY'))
         ) {
           inRange = false;
         }

--- a/src/datetime-picker.tsx
+++ b/src/datetime-picker.tsx
@@ -478,12 +478,12 @@ const DateTimePicker = (
               startDate: isStart
                 ? dayjs(selected).toDate()
                 : start
-                  ? dayjs.tz(start).toDate()
+                  ? dayjs(start).toDate()
                   : start,
               endDate: !isStart
-                ? dayjs.tz(getEndOfDay(selected), timeZone).toDate()
+                ? dayjs(getEndOfDay(selected)).toDate()
                 : end
-                  ? dayjs.tz(getEndOfDay(end), timeZone).toDate()
+                  ? dayjs(getEndOfDay(end)).toDate()
                   : end,
             });
           }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -170,7 +170,11 @@ export function isDateBetween(
     return false;
   }
 
-  return dayjs(date) <= endDate && dayjs(date) >= startDate;
+  const current = dayjs(date).valueOf();
+  const start = dayjs(startDate).valueOf();
+  const end = dayjs(endDate).valueOf();
+
+  return current >= start && current <= end;
 }
 
 /**
@@ -407,6 +411,10 @@ export function getEndOfDay(date: DateType): DateType {
  * @returns unix timestamp
  */
 export function dateToUnix(date: DateType): number {
+  if (!date) {
+    return Number.NaN;
+  }
+
   return dayjs(date).unix();
 }
 
@@ -421,7 +429,12 @@ export function removeTime(
   date: DateType,
   timeZone: string | undefined
 ): DateType {
-  return date ? dayjs.tz(date, timeZone).startOf('day') : undefined;
+  if (!date) {
+    return undefined;
+  }
+
+  const base = dayjs(date);
+  return timeZone ? base.tz(timeZone).startOf('day') : base.startOf('day');
 }
 
 /**


### PR DESCRIPTION
This fixes #246

- dateToUnix now returns NaN for empty values instead of “now”.
- Prevents false comparisons when no start/end exists yet.
- isDateBetween now uses numeric timestamps explicitly.
- Removes fragile object coercion behavior and keeps comparisons deterministic.
- removeTime now normalizes from an existing parsed date and only applies timezone when needed.
- Avoids double/ambiguous parsing.
- days.tsx now checks startDate && endDate before “same-day range” comparison.
- Prevents accidentally evaluating dayjs(undefined) and collapsing range styling.
- onChange in range mode now converts already-normalized dates directly.

**- So in short: it fixed because we made the range pipeline strictly compare real dates only, never “fallback now”, and avoid double parsing — which was especially visible in Jalali mode.**