### PR TITLE
fix: improve timezone handling for date-only and range selection

### DIFF
--- a/example/app/bottom-sheet.tsx
+++ b/example/app/bottom-sheet.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from 'react';
-import { Button, StyleSheet } from 'react-native';
+import { Button, StyleSheet, View, Text } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import {
   BottomSheetModal,
@@ -10,6 +10,7 @@ import DateTimePicker, {
   DateType,
   useDefaultStyles,
 } from 'react-native-ui-datepicker';
+import dayjs from 'dayjs';
 
 export default function BottomSheetScreen() {
   const defaultStyles = useDefaultStyles();
@@ -29,6 +30,19 @@ export default function BottomSheetScreen() {
   //   console.log('handleSheetChanges', index);
   // }, []);
 
+  const timezone = 'Europe/Prague';
+  const today = dayjs().tz(timezone).format('YYYY-MM-DD');
+
+  const minDate = dayjs
+    .tz(today, 'YYYY-MM-DD', timezone)
+    .subtract(2, 'day')
+
+
+  const maxDate = dayjs
+    .tz(today, 'YYYY-MM-DD', timezone)
+    .add(2, 'day')
+
+
   return (
     <GestureHandlerRootView style={styles.container}>
       <BottomSheetModalProvider>
@@ -38,15 +52,21 @@ export default function BottomSheetScreen() {
           //onChange={handleSheetChanges}
         >
           <BottomSheetView style={styles.contentContainer}>
+            <View>
+              <Text>{date ? dayjs(date).utc().format() : 'Not selected'}</Text>
+            </View>
             <DateTimePicker
               styles={defaultStyles}
               mode="single"
               date={date}
               onChange={(params) => setDate(params.date)}
-              firstDayOfWeek={6}
+              firstDayOfWeek={1}
               multiRangeMode
               showOutsideDays
               timePicker
+              timeZone={timezone}
+              minDate={minDate}
+              maxDate={maxDate}
               //calendar="jalali"
               //locale="en"
               //numerals="arabext"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ui-datepicker",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Customizable date picker for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/components/days.tsx
+++ b/src/components/days.tsx
@@ -45,16 +45,17 @@ const Days = () => {
   } = useCalendarContext();
 
   const style = useMemo(() => createDefaultStyles(isRTL), [isRTL]);
-
-  const { year, month, hour, minute } = getParsedDate(currentDate);
+  const { year, month } = getParsedDate(currentDate);
 
   const handleSelectDate = useCallback(
     (selectedDate: DateType) => {
-      const newDate = getDate(selectedDate).hour(hour).minute(minute);
+      const newDate = (
+        timeZone ? dayjs(selectedDate).tz(timeZone) : getDate(selectedDate)
+      ).startOf('day');
 
       onSelectDate(newDate);
     },
-    [onSelectDate, hour, minute]
+    [onSelectDate, timeZone]
   );
 
   const containerStyle = useMemo(
@@ -72,7 +73,7 @@ const Days = () => {
       prevMonthOffset,
       daysInCurrentMonth,
       daysInNextMonth,
-    } = getDaysInMonth(currentDate, showOutsideDays, firstDayOfWeek);
+    } = getDaysInMonth(currentDate, showOutsideDays, firstDayOfWeek, timeZone);
 
     return getMonthDays(
       currentDate,
@@ -86,7 +87,8 @@ const Days = () => {
       prevMonthOffset,
       daysInCurrentMonth,
       daysInNextMonth,
-      numerals
+      numerals,
+      timeZone
     ).map((day, index) => {
       if (!day) return null;
 
@@ -94,7 +96,8 @@ const Days = () => {
       let rightCrop = day.dayOfMonth === fullDaysInMonth;
       const isFirstDayOfMonth = day.dayOfMonth === 1;
       const isLastDayOfMonth = day.dayOfMonth === fullDaysInMonth;
-      const isToday = areDatesOnSameDay(day.date, today);
+      const isToday = areDatesOnSameDay(day.date, today, timeZone);
+
       let inRange = false;
       let isSelected = false;
       let isCrop = false;
@@ -104,8 +107,12 @@ const Days = () => {
 
       if (mode === 'range') {
         rightCrop = false;
-        const selectedStartDay = areDatesOnSameDay(day.date, startDate);
-        const selectedEndDay = areDatesOnSameDay(day.date, endDate);
+        const selectedStartDay = areDatesOnSameDay(
+          day.date,
+          startDate,
+          timeZone
+        );
+        const selectedEndDay = areDatesOnSameDay(day.date, endDate, timeZone);
         isSelected = selectedStartDay || selectedEndDay;
         inRange = isDateBetween(day.date, { startDate, endDate });
 
@@ -131,18 +138,20 @@ const Days = () => {
         rangeEnd = inRange && rightCrop;
       } else if (mode === 'multiple') {
         const safeDates = dates || [];
-        isSelected = safeDates.some((d) => areDatesOnSameDay(day.date, d));
+        isSelected = safeDates.some((d) =>
+          areDatesOnSameDay(day.date, d, timeZone)
+        );
 
         // if the selected days in a row, implements range mode style to selected days
         if (multiRangeMode) {
-          const yesterday = dayjs(day.date).subtract(1, 'day');
-          const tomorrow = dayjs(day.date).add(1, 'day');
+          const yesterday = dayjs(day.date).subtract(1, 'day').tz(timeZone);
+          const tomorrow = dayjs(day.date).add(1, 'day').tz(timeZone);
 
           const yesterdaySelected = safeDates.some((d) =>
-            areDatesOnSameDay(d, yesterday)
+            areDatesOnSameDay(d, yesterday, timeZone)
           );
           const tomorrowSelected = safeDates.some((d) =>
-            areDatesOnSameDay(d, tomorrow)
+            areDatesOnSameDay(d, tomorrow, timeZone)
           );
 
           // Reset all flags
@@ -184,7 +193,7 @@ const Days = () => {
           rangeEnd = inRange && rightCrop;
         }
       } else if (mode === 'single') {
-        isSelected = areDatesOnSameDay(day.date, date);
+        isSelected = areDatesOnSameDay(day.date, date, timeZone);
       }
 
       return {

--- a/src/datetime-picker.tsx
+++ b/src/datetime-picker.tsx
@@ -8,8 +8,6 @@ import React, {
 import { I18nManager } from 'react-native';
 import {
   dateToUnix,
-  getEndOfDay,
-  getStartOfDay,
   areDatesOnSameDay,
   removeTime,
 } from './utils';
@@ -31,7 +29,7 @@ import type {
 } from './types';
 import Calendar from './components/calendar';
 import { useDeepCompareMemo } from './utils';
-import dayjs from 'dayjs';
+import dayjs, { Dayjs } from 'dayjs';
 import localeData from 'dayjs/plugin/localeData';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
@@ -294,12 +292,15 @@ const DateTimePicker = (
 
   useEffect(() => {
     if (mode === 'single') {
-      let _date =
-        (date &&
-          (timePicker
-            ? dayjs.tz(date, timeZone)
-            : getStartOfDay(dayjs.tz(date, timeZone)))) ??
-        date;
+      let _date: Dayjs | undefined;
+
+      if (date) {
+        _date = timeZone ? dayjs(date).tz(timeZone) : dayjs(date);
+
+        if (!timePicker) {
+          _date = _date.startOf('day');
+        }
+      }
 
       if (_date && maxDate && dayjs.tz(_date, timeZone).isAfter(maxDate)) {
         _date = dayjs.tz(maxDate, timeZone);
@@ -395,9 +396,9 @@ const DateTimePicker = (
     (selectedDate: DateType) => {
       if (onChange) {
         if (mode === 'single') {
-          const newDate = timePicker
-            ? dayjs.tz(selectedDate, timeZone)
-            : dayjs.tz(getStartOfDay(selectedDate), timeZone);
+          const newDate = (
+            timeZone ? dayjs(selectedDate).tz(timeZone) : dayjs(selectedDate)
+          ).startOf('day');
 
           dispatch({
             type: CalendarActionKind.CHANGE_CURRENT_DATE,
@@ -405,7 +406,7 @@ const DateTimePicker = (
           });
 
           (onChange as SingleChange)({
-            date: newDate ? dayjs(newDate).toDate() : newDate,
+            date: newDate.toDate(),
           });
         } else if (mode === 'range') {
           // set time to 00:00:00
@@ -474,27 +475,39 @@ const DateTimePicker = (
               endDate: undefined,
             });
           } else {
-            (onChange as RangeChange)({
-              startDate: isStart
-                ? dayjs(selected).toDate()
-                : start
-                  ? dayjs(start).toDate()
-                  : start,
-              endDate: !isStart
-                ? dayjs(getEndOfDay(selected)).toDate()
-                : end
-                  ? dayjs(getEndOfDay(end)).toDate()
-                  : end,
-            });
+            const startDate = isStart
+              ? (timeZone ? dayjs(selected).tz(timeZone) : dayjs(selected))
+                  .startOf('day')
+                  .toDate()
+              : start
+                ? (timeZone ? dayjs(start).tz(timeZone) : dayjs(start))
+                    .startOf('day')
+                    .toDate()
+                : start;
+
+            const endDate = !isStart
+              ? (timeZone ? dayjs(selected).tz(timeZone) : dayjs(selected))
+                  .endOf('day')
+                  .toDate()
+              : end
+                ? (timeZone ? dayjs(end).tz(timeZone) : dayjs(end))
+                    .endOf('day')
+                    .toDate()
+                : end;
+            (onChange as RangeChange)({ startDate, endDate });
           }
         } else if (mode === 'multiple') {
           const safeDates = (stateRef.current.dates as DateType[]) || [];
           const newDate = dayjs(selectedDate, timeZone).startOf('day');
 
-          const exists = safeDates.some((ed) => areDatesOnSameDay(ed, newDate));
+          const exists = safeDates.some((ed) =>
+            areDatesOnSameDay(ed, newDate, timeZone)
+          );
 
           const newDates = exists
-            ? safeDates.filter((ed) => !areDatesOnSameDay(ed, newDate))
+            ? safeDates.filter(
+                (ed) => !areDatesOnSameDay(ed, newDate, timeZone)
+              )
             : [...safeDates, newDate];
 
           if (max && newDates.length > max) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -134,16 +134,22 @@ export const getDateYear = (date: DateType) => dayjs(date).year();
  *
  * @param a - date to check
  * @param b - date to check
+ * @param timeZone - timeZone
  *
  * @returns true if dates are on the same day, false otherwise
  */
-export function areDatesOnSameDay(a: DateType, b: DateType) {
+export function areDatesOnSameDay(a: DateType, b: DateType, timeZone?: string) {
   if (!a || !b) {
     return false;
   }
 
-  const date_a = dayjs(a).format(DATE_FORMAT);
-  const date_b = dayjs(b).format(DATE_FORMAT);
+  const date_a = timeZone
+    ? dayjs(a).tz(timeZone).format(DATE_FORMAT)
+    : dayjs(a).format(DATE_FORMAT);
+
+  const date_b = timeZone
+    ? dayjs(b).tz(timeZone).format(DATE_FORMAT)
+    : dayjs(b).format(DATE_FORMAT);
 
   return date_a === date_b;
 }
@@ -192,38 +198,57 @@ export function isDateDisabled(
     maxDate,
     enabledDates,
     disabledDates,
+    timeZone,
   }: {
     minDate?: DateType;
     maxDate?: DateType;
-    enabledDates?: DateType[] | ((date: DateType) => boolean) | undefined;
-    disabledDates?: DateType[] | ((date: DateType) => boolean) | undefined;
+    enabledDates?: DateType[] | ((date: DateType) => boolean);
+    disabledDates?: DateType[] | ((date: DateType) => boolean);
+    timeZone?: string;
   }
 ): boolean {
-  if (minDate && date.isBefore(dayjs(minDate).startOf('day'))) {
-    return true;
+  const zonedDate = timeZone ? dayjs(date).tz(timeZone) : dayjs(date);
+
+  if (minDate) {
+    const min = (
+      timeZone ? dayjs(minDate).tz(timeZone) : dayjs(minDate)
+    ).startOf('day');
+
+    if (zonedDate.isBefore(min)) {
+      return true;
+    }
   }
-  if (maxDate && date.isAfter(dayjs(maxDate).endOf('day'))) {
-    return true;
+
+  if (maxDate) {
+    const max = (timeZone ? dayjs(maxDate).tz(timeZone) : dayjs(maxDate)).endOf(
+      'day'
+    );
+
+    if (zonedDate.isAfter(max)) {
+      return true;
+    }
   }
 
   if (enabledDates) {
     if (Array.isArray(enabledDates)) {
       const isEnabled = enabledDates.some((enabledDate) =>
-        areDatesOnSameDay(date, enabledDate)
+        areDatesOnSameDay(date, enabledDate, timeZone)
       );
+
       return !isEnabled;
-    } else if (enabledDates instanceof Function) {
-      return !enabledDates(date);
     }
-  } else if (disabledDates) {
+
+    return !enabledDates(date);
+  }
+
+  if (disabledDates) {
     if (Array.isArray(disabledDates)) {
-      const isDisabled = disabledDates.some((disabledDate) =>
-        areDatesOnSameDay(date, disabledDate)
+      return disabledDates.some((disabledDate) =>
+        areDatesOnSameDay(date, disabledDate, timeZone)
       );
-      return isDisabled;
-    } else if (disabledDates instanceof Function) {
-      return disabledDates(date);
     }
+
+    return disabledDates(date);
   }
 
   return false;
@@ -338,13 +363,15 @@ export const getYearRange = (year: number) => {
 export function getDaysInMonth(
   date: DateType,
   showOutsideDays: boolean | undefined,
-  firstDayOfWeek: number
+  firstDayOfWeek: number,
+  timeZone?: string
 ) {
-  const daysInCurrentMonth = dayjs(date).daysInMonth();
+  const zonedDate = timeZone ? dayjs(date).tz(timeZone) : dayjs(date);
+  const daysInCurrentMonth = zonedDate.daysInMonth();
 
-  const prevMonthDays = dayjs(date).add(-1, 'month').daysInMonth();
-  const firstDay = dayjs(date).date(1 - firstDayOfWeek);
-  const prevMonthOffset = firstDay.day() % 7;
+  const prevMonthDays = zonedDate.add(-1, 'month').daysInMonth();
+  const firstDateOfMonth = zonedDate.date(1);
+  const prevMonthOffset = (firstDateOfMonth.day() - firstDayOfWeek + 7) % 7;
   const daysInPrevMonth = showOutsideDays ? prevMonthOffset : 0;
   const monthDaysOffset = prevMonthOffset + daysInCurrentMonth;
   const daysInNextMonth = showOutsideDays
@@ -379,28 +406,6 @@ export function getFirstDayOfMonth(
 ): number {
   const d = getDate(date);
   return d.date(1 - firstDayOfWeek).day();
-}
-
-/**
- * Get start of day
- *
- * @param date - date to get start of day from
- *
- * @returns start of day
- */
-export function getStartOfDay(date: DateType): DateType {
-  return dayjs(date).startOf('day');
-}
-
-/**
- * Get end of day
- *
- * @param date - date to get end of day from
- *
- * @returns end of day
- */
-export function getEndOfDay(date: DateType): DateType {
-  return dayjs(date).endOf('day');
 }
 
 /**
@@ -455,6 +460,18 @@ export const getParsedDate = (date: DateType) => {
   };
 };
 
+export const createCalendarDate = (
+  baseMonth: dayjs.Dayjs,
+  day: number,
+  timeZone?: string
+) => {
+  const value = `${baseMonth.format('YYYY-MM')}-${String(day).padStart(2, '0')}`;
+
+  return timeZone
+    ? dayjs.tz(value, DATE_FORMAT, timeZone)
+    : dayjs(value, DATE_FORMAT);
+};
+
 /**
  * Calculate month days array based on current date
  *
@@ -484,14 +501,18 @@ export const getMonthDays = (
   prevMonthOffset: number,
   daysInCurrentMonth: number,
   daysInNextMonth: number,
-  numerals: Numerals
+  numerals: Numerals,
+  timeZone?: string
 ): CalendarDay[] => {
-  const date = dayjs(datetime);
+  const date = timeZone ? dayjs(datetime).tz(timeZone) : dayjs(datetime);
+  const prevMonth = date.add(-1, 'month');
+  const nextMonth = date.add(1, 'month');
 
   const prevDays = showOutsideDays
     ? Array.from({ length: prevMonthOffset }, (_, index) => {
         const number = index + (prevMonthDays - prevMonthOffset + 1);
-        const thisDay = date.add(-1, 'month').date(number);
+        const thisDay = createCalendarDate(prevMonth, number, timeZone);
+
         return generateCalendarDay(
           number,
           thisDay,
@@ -502,14 +523,17 @@ export const getMonthDays = (
           false,
           index + 1,
           firstDayOfWeek,
-          numerals
+          numerals,
+          timeZone
         );
       })
     : Array(prevMonthOffset).fill(null);
 
+
   const currentDays = Array.from({ length: daysInCurrentMonth }, (_, index) => {
     const day = index + 1;
-    const thisDay = date.date(day);
+    const thisDay = createCalendarDate(date, day, timeZone);
+
     return generateCalendarDay(
       day,
       thisDay,
@@ -520,13 +544,15 @@ export const getMonthDays = (
       true,
       prevMonthOffset + day,
       firstDayOfWeek,
-      numerals
+      numerals,
+      timeZone
     );
   });
 
   const nextDays = Array.from({ length: daysInNextMonth }, (_, index) => {
     const day = index + 1;
-    const thisDay = date.add(1, 'month').date(day);
+    const thisDay = createCalendarDate(nextMonth, day, timeZone);
+
     return generateCalendarDay(
       day,
       thisDay,
@@ -537,7 +563,8 @@ export const getMonthDays = (
       false,
       daysInCurrentMonth + prevMonthOffset + day,
       firstDayOfWeek,
-      numerals
+      numerals,
+      timeZone
     );
   });
 
@@ -569,9 +596,12 @@ const generateCalendarDay = (
   isCurrentMonth: boolean,
   dayOfMonth: number,
   firstDayOfWeek: number,
-  numerals: Numerals
+  numerals: Numerals,
+  timeZone?: string,
 ) => {
-  const startOfWeek = dayjs(date).startOf('week').add(firstDayOfWeek, 'day');
+  const startOfWeek = timeZone
+    ? dayjs(date).startOf('week').add(firstDayOfWeek, 'day').tz(timeZone)
+    : dayjs(date).startOf('week').add(firstDayOfWeek, 'day');
 
   return {
     text: formatNumber(number, numerals),
@@ -582,6 +612,7 @@ const generateCalendarDay = (
       maxDate,
       enabledDates,
       disabledDates,
+      timeZone,
     }),
     isCurrentMonth,
     dayOfMonth,


### PR DESCRIPTION
## Summary

This PR fixes several timezone-related issues in the date picker when using non-local timezones (e.g. school timezone differs from device timezone).

The issues became visible mainly when testing from extreme timezones such as `Pacific/Kiritimati (UTC+14)`.

## Fixed issues

- incorrect `startOf('day')` / `endOf('day')` handling in range mode
- date-only selection shifting by one day in non-local timezones
- inconsistent handling between single and range modes
- incorrect all-day range boundaries
- timezone context being lost during internal dayjs conversions
- range selection returning current time instead of proper day boundaries

## Changes

### Single mode
- unified timezone conversion flow using:
  ```ts
  dayjs(date).tz(timeZone)

### Range mode
- normalized:
- start date → startOf('day')
- end date → endOf('day')
- aligned behavior with single mode timezone handling

### Internal cleanup
- removed nested/unnecessary dayjs(dayjs.tz(...)) conversions
- simplified timezone-aware date normalization flow

## Testing

### Tested on:
- Web
- Android
- iOS Simulator

### Tested with:
- local timezone matching school timezone
- different local timezone
- extreme timezone offsets (UTC+12, UTC+14)

### Verified:
- no day shifting
- correct all-day behavior
- correct serialization boundaries
- correct timezone-aware formatting