### PR TITLE
feat: add containerStyle prop to DateTimePicker and Calendar componen…

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ export function Calendar() {
 | `monthCaptionFormat` | `"short"` \| `"full"`               | Defines the format for displaying the month caption.      |
 | `hideHeader`         | `boolean`                           | Whether to hide the calendar header.                      |
 | `hideWeekdays`       | `boolean`                           | Whether to hide the weekdays row.                         |
+| `showMonthSelector`  | `boolean`                           | When `true`, always show the month selector (including in year view). When `false`, hide it. When omitted, show except in year view. |
 | `disableMonthPicker` | `boolean`                           | Whether to disable the month picker.                      |
 | `disableYearPicker`  | `boolean`                           | Whether to disable the year picker.                       |
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ DateTimePicker comes with a minimal style, making it easy to extend and customiz
 
 | Name              | Type            | Description                                                     |
 | ----------------- | --------------- | --------------------------------------------------------------- |
-| `style`           | `ViewStyle`     | style for the calendar container.                               |
+| `style`           | `ViewStyle`     | Style for the outer calendar container (header and body).       |
+| `containerStyle`  | `ViewStyle`     | Style for the inner calendar body (day, month, year, or time view). Does not override `containerHeight`. |
 | `className`       | `string`        | className for the calendar container.                           |
 | `styles`          | `Styles`        | Custom styles for specific components inside the calendar.      |
 | `classNames`      | `ClassNames`    | Custom classNames for specific components inside the calendar.  |

--- a/src/components/calendar.tsx
+++ b/src/components/calendar.tsx
@@ -24,15 +24,17 @@ const Calendar = () => {
     styles = {},
     classNames = {},
     containerHeight,
+    containerStyle: containerStyleProps,
     navigationPosition,
     isRTL,
   } = useCalendarContext();
 
   const containerStyle: ViewStyle = useMemo(
     () => ({
+      ...containerStyleProps,
       height: containerHeight,
     }),
-    [containerHeight]
+    [containerHeight, containerStyleProps]
   );
 
   return (

--- a/src/components/header/selectors.tsx
+++ b/src/components/header/selectors.tsx
@@ -11,7 +11,12 @@ type Props = {
 };
 
 const Selectors = ({ position }: Props) => {
-  const { mode, calendarView, timePicker } = useCalendarContext();
+  const { mode, calendarView, timePicker, showMonthSelector } =
+    useCalendarContext();
+
+  const showMonth =
+    showMonthSelector === true ||
+    (showMonthSelector !== false && calendarView !== 'year');
 
   return (
     <View
@@ -27,7 +32,7 @@ const Selectors = ({ position }: Props) => {
       ]}
     >
       <View style={defaultStyles.monthAndYear}>
-        {calendarView !== 'year' ? <MonthButton /> : null}
+        {showMonth && <MonthButton />}
         <YearButton />
       </View>
       {timePicker && mode === 'single' && calendarView !== 'year' ? (

--- a/src/components/header/year-button.tsx
+++ b/src/components/header/year-button.tsx
@@ -20,17 +20,17 @@ const YearButton = () => {
   } = useCalendarContext();
 
   const years = getYearRange(currentYear);
+  const isYearView = calendarView === 'year';
 
-  const yearText =
-    calendarView === 'year'
-      ? `${formatNumber(years[0] || 0, numerals)} - ${formatNumber(years[years.length - 1] || 0, numerals)}`
-      : formatNumber(
-          parseInt(dayjs(currentDate).calendar(calendar).format('YYYY')),
-          numerals
-        );
+  const year = formatNumber(
+    parseInt(dayjs(currentDate).calendar(calendar).format('YYYY')),
+    numerals
+  );
+  const yearRange = `${formatNumber(years[0] || 0, numerals)} - ${formatNumber(years[years.length - 1] || 0, numerals)}`;
+  const label = isYearView ? yearRange : year;
 
   const handlePress = () => {
-    setCalendarView(calendarView === 'year' ? 'day' : 'year');
+    setCalendarView(isYearView ? 'day' : 'year');
     onChangeYear(getDateYear(currentDate));
   };
 
@@ -38,8 +38,9 @@ const YearButton = () => {
     return (
       <>
         {components.YearSelector({
-          text: yearText,
-          isOpen: calendarView === 'year',
+          year,
+          yearRange,
+          isOpen: isYearView,
           onPress: disableYearPicker ? () => {} : handlePress,
         })}
       </>
@@ -62,7 +63,7 @@ const YearButton = () => {
           style={styles?.year_selector_label}
           className={classNames?.year_selector_label}
         >
-          {yearText}
+          {label}
         </Text>
       </View>
     </Pressable>

--- a/src/datetime-picker.tsx
+++ b/src/datetime-picker.tsx
@@ -122,6 +122,7 @@ const DateTimePicker = (
     onMonthChange = () => {},
     onYearChange = () => {},
     use12Hours,
+    containerStyle,
   } = props;
 
   const allowRangeReset =
@@ -723,6 +724,7 @@ const DateTimePicker = (
       ...handlerContextValue,
       ...styleContextValue,
       components: memoizedComponents,
+      containerStyle,
     }),
     [
       state,
@@ -730,6 +732,7 @@ const DateTimePicker = (
       handlerContextValue,
       styleContextValue,
       memoizedComponents,
+      containerStyle,
     ]
   );
 

--- a/src/datetime-picker.tsx
+++ b/src/datetime-picker.tsx
@@ -114,6 +114,7 @@ const DateTimePicker = (
     multiRangeMode,
     hideHeader,
     hideWeekdays,
+    showMonthSelector,
     disableMonthPicker,
     disableYearPicker,
     components = {},
@@ -652,6 +653,7 @@ const DateTimePicker = (
       multiRangeMode,
       hideHeader,
       hideWeekdays,
+      showMonthSelector,
       disableMonthPicker,
       disableYearPicker,
       style,
@@ -682,6 +684,7 @@ const DateTimePicker = (
       multiRangeMode,
       hideHeader,
       hideWeekdays,
+      showMonthSelector,
       disableMonthPicker,
       disableYearPicker,
       style,
@@ -725,6 +728,7 @@ const DateTimePicker = (
       ...styleContextValue,
       components: memoizedComponents,
       containerStyle,
+      showMonthSelector,
     }),
     [
       state,
@@ -733,6 +737,7 @@ const DateTimePicker = (
       styleContextValue,
       memoizedComponents,
       containerStyle,
+      showMonthSelector,
     ]
   );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -178,6 +178,7 @@ export interface DatePickerBaseProps {
   use12Hours?: boolean;
   initialView?: CalendarViews;
   containerHeight?: number;
+  containerStyle?: ViewStyle;
   weekdaysHeight?: number;
   style?: ViewStyle;
   className?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,8 +126,10 @@ export type CalendarMonthSelectorProps = {
 };
 
 export type CalendarYearSelectorProps = {
-  /** The formatted year or year-range shown in the header (e.g. "2025" or "2024 - 2035") */
-  text: string;
+  /** Formatted active year from the current date (e.g. "2025") */
+  year: string;
+  /** Formatted visible year range in the year picker (e.g. "2020 - 2029") */
+  yearRange: string;
   /** Whether the year-picker view is currently open */
   isOpen: boolean;
   /** Toggles the year-picker view */
@@ -191,6 +193,11 @@ export interface DatePickerBaseProps {
   multiRangeMode?: boolean;
   hideHeader?: boolean;
   hideWeekdays?: boolean;
+  /**
+   * When `true`, always show the month selector (including in year view).
+   * When `false`, hide it. When omitted, show it except in year view.
+   */
+  showMonthSelector?: boolean;
   disableMonthPicker?: boolean;
   disableYearPicker?: boolean;
   components?: CalendarComponents;


### PR DESCRIPTION
Add `containerStyle` prop, allowing the styles to be added to the calendar body not the header.
Add `showMonthSelector` prop, allowing the button to show up when the view is on `year` mode.
Expose `year` and `yearRange` prop to the `YearSelector` props.