### PR TITLE
fix: apply month and year props atomically

### DIFF
--- a/src/__tests__/month-year-props.test.tsx
+++ b/src/__tests__/month-year-props.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import DateTimePicker from '../datetime-picker';
+import 'dayjs/locale/en';
+
+describe('month/year props', () => {
+  test('should display january when month={0} is passed', () => {
+    render(<DateTimePicker mode="single" month={0} year={2026} />);
+    expect(screen.getByText('January')).toBeVisible();
+    expect(screen.getByText('2026')).toBeVisible();
+  });
+
+  test('should apply month and year changing together across a year boundary (backward)', () => {
+    const { rerender } = render(
+      <DateTimePicker mode="single" month={1} year={2027} />
+    );
+    expect(screen.getByText('February')).toBeVisible();
+    expect(screen.getByText('2027')).toBeVisible();
+
+    // February 2027 -> January 2027 -> December 2026
+    rerender(<DateTimePicker mode="single" month={0} year={2027} />);
+    rerender(<DateTimePicker mode="single" month={11} year={2026} />);
+
+    expect(screen.getByText('December')).toBeVisible();
+    expect(screen.getByText('2026')).toBeVisible();
+  });
+
+  test('should apply month and year changing together across a year boundary (forward)', () => {
+    const { rerender } = render(
+      <DateTimePicker mode="single" month={11} year={2026} />
+    );
+    expect(screen.getByText('December')).toBeVisible();
+    expect(screen.getByText('2026')).toBeVisible();
+
+    // December 2026 -> January 2027
+    rerender(<DateTimePicker mode="single" month={0} year={2027} />);
+
+    expect(screen.getByText('January')).toBeVisible();
+    expect(screen.getByText('2027')).toBeVisible();
+  });
+});

--- a/src/datetime-picker.tsx
+++ b/src/datetime-picker.tsx
@@ -169,7 +169,7 @@ const DateTimePicker = (
       initialDate = dayjs(minDate);
     }
 
-    if (month !== undefined && month && month >= 0 && month <= 11) {
+    if (month !== undefined && month >= 0 && month <= 11) {
       initialDate = initialDate.month(month);
     }
 
@@ -603,17 +603,39 @@ const DateTimePicker = (
     [dispatch]
   );
 
+  // The month/year props are applied in ONE effect with ONE dispatch. Two
+  // separate effects each build an absolute date from stateRef.current, which
+  // is stale for whichever effect runs second in the same flush — when both
+  // props change together (e.g. navigating across a year boundary), the last
+  // dispatch wins with a date that has only one of the two changes applied.
   useEffect(() => {
-    if (month !== undefined && month >= 0 && month <= 11) {
-      onSelectMonth(month);
+    const hasMonth = month !== undefined && month >= 0 && month <= 11;
+    const hasYear = year !== undefined && year >= 0;
+    if (!hasMonth && !hasYear) {
+      return;
     }
-  }, [month]);
-
-  useEffect(() => {
-    if (year !== undefined && year >= 0) {
-      onSelectYear(year);
+    // Pin the day-of-month first so applying month/year from the 29th-31st
+    // can never overflow into the following month.
+    let newDate = dayjs(stateRef.current.currentDate).date(1);
+    if (hasYear) {
+      if (year !== newDate.year()) {
+        onYearChange(year!);
+      }
+      newDate = newDate.year(year!);
     }
-  }, [year]);
+    if (hasMonth) {
+      if (month !== newDate.month()) {
+        onMonthChange(month!);
+      }
+      newDate = newDate.month(month!);
+    }
+    dispatch({
+      type: CalendarActionKind.CHANGE_CURRENT_DATE,
+      payload: newDate,
+    });
+    setCalendarView('day');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [month, year]);
 
   const memoizedStyles = useDeepCompareMemo({ ...styles }, [styles]);
 


### PR DESCRIPTION
## Bug

When the `month` and `year` props change together in one render — e.g. a custom header navigating from January 2027 back to December 2026 — the calendar lands on the wrong month entirely (January **2026** in that example). With a `minDate` nearby, that renders as a fully disabled grid: our testers reported "December is greyed out" when navigating back across a year boundary. The forward crossing is affected too, but self-corrects on the next navigation, so it mostly goes unnoticed.

## Root cause

The `month` and `year` props are applied by two separate effects, each dispatching an **absolute** date built from `stateRef.current`:

```tsx
useEffect(() => {
  if (month !== undefined && month >= 0 && month <= 11) {
    onSelectMonth(month);   // dispatches dayjs(stateRef.current.currentDate).month(month)
  }
}, [month]);

useEffect(() => {
  if (year !== undefined && year >= 0) {
    onSelectYear(year);     // dispatches dayjs(stateRef.current.currentDate).year(year)
  }
}, [year]);
```

Both run in the same effect flush, so the second effect reads a stale `stateRef` (the first dispatch hasn't re-rendered yet). With `month` 0→11 and `year` 2027→2026:

1. month effect: Jan 2027 → `.month(11)` → dispatches **Dec 2027**
2. year effect: still sees Jan 2027 → `.year(2026)` → dispatches **Jan 2026**
3. last dispatch wins → the calendar shows **January 2026**

## Fix

Merge the two prop-sync effects into a single effect with a single dispatch that applies year and month to one date. The day-of-month is pinned to 1 before applying them so a sync while `currentDate` sits on the 29th–31st can never overflow into the following month (e.g. Oct 31 → Feb).

Also fixes `month={0}`: the initial-state guard `month !== undefined && month && …` treated January (0) as falsy and skipped it.

## Tests

Three new tests in `src/__tests__/month-year-props.test.tsx`: backward year crossing, forward year crossing, and `month={0}`. All three fail on current `main` and pass with this change. `yarn test` (5/5), `yarn typecheck`, and `yarn lint` are clean.