### PR TITLE
fix: compare range fill at day granularity in isDateBetween

### DIFF
--- a/src/__tests__/is-date-between.test.tsx
+++ b/src/__tests__/is-date-between.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import dayjs from 'dayjs';
+import DateTimePicker from '../datetime-picker';
+import { isDateBetween } from '../utils';
+import 'dayjs/locale/en';
+
+describe('isDateBetween', () => {
+  // days.tsx asks isDateBetween about calendar day cells. Those cells inherit
+  // currentDate's time of day (getMonthDays builds them via currentDate.date(n)),
+  // while range endpoints are stored at start of day (onSelectDate uses
+  // getStartOfDay). The answer must therefore be day-granular.
+  test('counts the end day when the cell carries a time of day', () => {
+    expect(
+      isDateBetween(dayjs('2026-08-20 15:22'), {
+        startDate: '2026-08-10',
+        endDate: '2026-08-20',
+      })
+    ).toBe(true);
+  });
+
+  test('counts the start day when the range bounds carry a time of day', () => {
+    expect(
+      isDateBetween(dayjs('2026-08-10 09:00'), {
+        startDate: '2026-08-10T18:00:00',
+        endDate: '2026-08-20',
+      })
+    ).toBe(true);
+  });
+
+  test('still excludes days outside the range', () => {
+    const range = { startDate: '2026-08-10', endDate: '2026-08-20' };
+    expect(isDateBetween(dayjs('2026-08-09 23:59'), range)).toBe(false);
+    expect(isDateBetween(dayjs('2026-08-21 00:00'), range)).toBe(false);
+  });
+
+  test('counts middle days', () => {
+    const range = { startDate: '2026-08-10', endDate: '2026-08-20' };
+    expect(isDateBetween(dayjs('2026-08-15 15:22'), range)).toBe(true);
+  });
+});
+
+describe('range fill day state', () => {
+  // Freeze the clock away from midnight: a picker rendered without a selection
+  // anchors currentDate at "now", and every day cell inherits that time of day.
+  beforeAll(() => {
+    jest.useFakeTimers({ now: new Date('2026-08-04T15:22:00') });
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  const rangeStartStyle = { backgroundColor: 'rgb(0, 0, 255)' };
+  const rangeEndStyle = { backgroundColor: 'rgb(255, 0, 0)' };
+  const rangeMiddleStyle = { backgroundColor: 'rgb(0, 255, 0)' };
+  const styles = {
+    range_start: rangeStartStyle,
+    range_end: rangeEndStyle,
+    range_middle: rangeMiddleStyle,
+  };
+
+  test('the end day keeps its range_end style when the picker was opened without a selection', () => {
+    const { rerender } = render(
+      <DateTimePicker mode="range" styles={styles} />
+    );
+
+    // A controlled consumer supplies the selection as date-only values.
+    rerender(
+      <DateTimePicker
+        mode="range"
+        startDate="2026-08-10"
+        endDate="2026-08-20"
+        styles={styles}
+      />
+    );
+
+    expect(screen.getByLabelText('10')).toHaveStyle(rangeStartStyle);
+    expect(screen.getByLabelText('15')).toHaveStyle(rangeMiddleStyle);
+    expect(screen.getByLabelText('20')).toHaveStyle(rangeEndStyle);
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -170,9 +170,15 @@ export function isDateBetween(
     return false;
   }
 
-  const current = dayjs(date).valueOf();
-  const start = dayjs(startDate).valueOf();
-  const end = dayjs(endDate).valueOf();
+  // Compare at day granularity: this is only ever asked about calendar day
+  // cells (days.tsx), and those inherit currentDate's time of day while the
+  // range endpoints are stored at start of day — a raw timestamp comparison
+  // drops the end day from the range whenever the cell's time is later than
+  // midnight. Day granularity also matches areDatesOnSameDay, which already
+  // decides the endpoints.
+  const current = dayjs(date).startOf('day').valueOf();
+  const start = dayjs(startDate).startOf('day').valueOf();
+  const end = dayjs(endDate).startOf('day').valueOf();
 
   return current >= start && current <= end;
 }


### PR DESCRIPTION
## Bug

In range mode, the **end day of a selected range loses its `range_end` styling** (and the start day can lose `range_start`) whenever the calendar's internal `currentDate` carries a time of day — which is the default: a picker rendered without an initial selection anchors `currentDate` at `dayjs()`, i.e. the current wall-clock time.

## Root cause

`isDateBetween` compares raw timestamps:

```ts
const current = dayjs(date).valueOf();
const start = dayjs(startDate).valueOf();
const end = dayjs(endDate).valueOf();
return current >= start && current <= end;
```

but its only caller (`days.tsx`) asks about **calendar day cells**, and those inherit `currentDate`'s time of day — `getMonthDays` builds each cell via `currentDate.date(n)`. Range endpoints, meanwhile, are stored at start of day (`onSelectDate` normalizes through `getStartOfDay`).

So with the picker opened at 15:22 and a range Aug 10 – Aug 20 selected, the end-day check is:

```
Aug 20 15:22  <=  Aug 20 00:00   →  false
```

`inRange` is false on the end day → `rangeEnd = inRange && rightCrop` is false → the `range_end` style / className silently never applies. The endpoints' *selected* circles still render (they use the day-granular `areDatesOnSameDay`), which makes the missing fill cap easy to miss but visible with any custom `range_end` styling. The start day has the mirrored problem when the bounds carry a later time than the cells.

## Fix

Normalize all three operands to `startOf('day')` — day granularity is the correct contract for a function that is only ever asked about calendar day cells, and it matches `areDatesOnSameDay`, which already decides the endpoints.

## Tests

New `src/__tests__/is-date-between.test.tsx`:
- unit: end day with a time-of-day cell, start day with time-carrying bounds, middle days, and outside-days exclusion;
- component: with the clock frozen at 15:22, render `mode="range"` with no selection, then supply `startDate`/`endDate` as date-only values and assert the day-10/15/20 cells carry `range_start`/`range_middle`/`range_end` styles.

The end-day/start-day cases fail on current `main` and pass with this change; `yarn test` (7/7), `yarn typecheck`, and `yarn lint` are clean.

Independent of #257 (different file, no shared commits).